### PR TITLE
refactor: migrate to generic data store for credential persistence

### DIFF
--- a/libpasskey/src/lib.rs
+++ b/libpasskey/src/lib.rs
@@ -24,19 +24,25 @@ pub use passkey::{
 
 pub use common::email_to_user_id;
 
-pub async fn init() -> Result<(), errors::PasskeyError> {
+use errors::PasskeyError;
+use storage::PasskeyStore;
+
+pub async fn init() -> Result<(), PasskeyError> {
     // Validate required environment variables early
     let _ = *config::PASSKEY_RP_ID;
 
     // Initialize libstorage's cache store first
     libstorage::init_cache_store()
         .await
-        .map_err(|e| errors::PasskeyError::Storage(e.to_string()))?;
+        .map_err(|e| PasskeyError::Storage(e.to_string()))?;
 
     // Initialize passkey's stores
-    config::init_challenge_store().await?;
-    config::init_credential_store().await?;
-    config::init_cache_store().await?;
+    // config::init_challenge_store().await?;
+    // config::init_credential_store().await?;
+    // config::init_cache_store().await?;
+
+    // Initialize the passkey store
+    PasskeyStore::init().await?;
 
     Ok(())
 }

--- a/libpasskey/src/passkey/types.rs
+++ b/libpasskey/src/passkey/types.rs
@@ -105,9 +105,25 @@ pub(super) struct ParsedClientData {
     pub(super) raw_data: Vec<u8>,
 }
 
+/// AuthenticatorData structure as defined in WebAuthn spec Level 2
+/// https://www.w3.org/TR/webauthn-2/#sctn-authenticator-data
 #[derive(Debug)]
 pub(super) struct AuthenticatorData {
+    /// SHA-256 hash of the RP ID (32 bytes)
     pub(super) rp_id_hash: Vec<u8>,
+
+    /// Flags (1 byte) indicating various attributes:
+    /// - Bit 0: User Present (UP)
+    /// - Bit 2: User Verified (UV)
+    /// - Bit 3: Backup Eligibility (BE) - Indicates if credential is discoverable
+    /// - Bit 4: Backup State (BS)
+    /// - Bit 6: Attested Credential Data Present (AT)
+    /// - Bit 7: Extension Data Present (ED)
     pub(super) flags: u8,
+
+    /// Signature counter (4 bytes), 32-bit unsigned big-endian integer
+    pub(super) counter: u32,
+
+    /// Raw authenticator data for verification
     pub(super) raw_data: Vec<u8>,
 }

--- a/libpasskey/src/storage/generic_data_store.rs
+++ b/libpasskey/src/storage/generic_data_store.rs
@@ -1,0 +1,343 @@
+use libstorage::GENERIC_DATA_STORE;
+use sqlx::{Pool, Postgres, Sqlite};
+
+use crate::errors::PasskeyError;
+use crate::types::{PublicKeyCredentialUserEntity, StoredCredential};
+
+pub struct PasskeyStore;
+
+impl PasskeyStore {
+    pub async fn init() -> Result<(), PasskeyError> {
+        let store = GENERIC_DATA_STORE.lock().await;
+
+        // Create table based on database type
+        if let Some(pool) = store.as_sqlite() {
+            create_tables_sqlite(pool).await
+        } else if let Some(pool) = store.as_postgres() {
+            create_tables_postgres(pool).await
+        } else {
+            Err(PasskeyError::Storage("Unsupported database type".into()))
+        }
+    }
+
+    pub async fn store_credential(
+        credential_id: String,
+        credential: StoredCredential,
+    ) -> Result<(), PasskeyError> {
+        let store = GENERIC_DATA_STORE.lock().await;
+
+        if let Some(pool) = store.as_sqlite() {
+            store_credential_sqlite(pool, &credential_id, &credential).await
+        } else if let Some(pool) = store.as_postgres() {
+            store_credential_postgres(pool, &credential_id, &credential).await
+        } else {
+            Err(PasskeyError::Storage("Unsupported database type".into()))
+        }
+    }
+
+    pub async fn get_credential(
+        credential_id: &str,
+    ) -> Result<Option<StoredCredential>, PasskeyError> {
+        let store = GENERIC_DATA_STORE.lock().await;
+
+        if let Some(pool) = store.as_sqlite() {
+            get_credential_sqlite(pool, credential_id).await
+        } else if let Some(pool) = store.as_postgres() {
+            get_credential_postgres(pool, credential_id).await
+        } else {
+            Err(PasskeyError::Storage("Unsupported database type".into()))
+        }
+    }
+
+    pub async fn get_credentials_by_user(
+        user_id: &str,
+    ) -> Result<Vec<StoredCredential>, PasskeyError> {
+        let store = GENERIC_DATA_STORE.lock().await;
+
+        if let Some(pool) = store.as_sqlite() {
+            get_credentials_by_user_sqlite(pool, user_id).await
+        } else if let Some(pool) = store.as_postgres() {
+            get_credentials_by_user_postgres(pool, user_id).await
+        } else {
+            Err(PasskeyError::Storage("Unsupported database type".into()))
+        }
+    }
+
+    pub async fn update_credential_counter(
+        credential_id: &str,
+        counter: u32,
+    ) -> Result<(), PasskeyError> {
+        let store = GENERIC_DATA_STORE.lock().await;
+
+        if let Some(pool) = store.as_sqlite() {
+            update_credential_counter_sqlite(pool, credential_id, counter).await
+        } else if let Some(pool) = store.as_postgres() {
+            update_credential_counter_postgres(pool, credential_id, counter).await
+        } else {
+            Err(PasskeyError::Storage("Unsupported database type".into()))
+        }
+    }
+}
+
+// SQLite implementations
+async fn create_tables_sqlite(pool: &Pool<Sqlite>) -> Result<(), PasskeyError> {
+    sqlx::query!(
+        r#"
+        CREATE TABLE IF NOT EXISTS passkey_credentials (
+            credential_id TEXT PRIMARY KEY NOT NULL,
+            public_key BLOB NOT NULL,
+            counter INTEGER NOT NULL DEFAULT 0,
+            user_handle TEXT NOT NULL,
+            user_name TEXT NOT NULL,
+            user_display_name TEXT NOT NULL,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(())
+}
+
+async fn store_credential_sqlite(
+    pool: &Pool<Sqlite>,
+    credential_id: &str,
+    credential: &StoredCredential,
+) -> Result<(), PasskeyError> {
+    sqlx::query!(
+        r#"
+        INSERT OR REPLACE INTO passkey_credentials 
+        (credential_id, public_key, counter, user_handle, user_name, user_display_name, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+        "#,
+        credential_id,
+        credential.public_key,
+        credential.counter as i64,
+        credential.user.user_handle,
+        credential.user.name,
+        credential.user.display_name,
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(())
+}
+
+async fn get_credential_sqlite(
+    pool: &Pool<Sqlite>,
+    credential_id: &str,
+) -> Result<Option<StoredCredential>, PasskeyError> {
+    let result = sqlx::query!(
+        r#"
+        SELECT public_key, counter, user_handle, user_name, user_display_name
+        FROM passkey_credentials
+        WHERE credential_id = ?
+        "#,
+        credential_id
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(result.map(|row| StoredCredential {
+        credential_id: credential_id.as_bytes().to_vec(),
+        public_key: row.public_key,
+        counter: row.counter as u32,
+        user: PublicKeyCredentialUserEntity {
+            user_handle: row.user_handle,
+            name: row.user_name,
+            display_name: row.user_display_name,
+        },
+    }))
+}
+
+async fn get_credentials_by_user_sqlite(
+    pool: &Pool<Sqlite>,
+    user_handle: &str,
+) -> Result<Vec<StoredCredential>, PasskeyError> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT credential_id, public_key, counter, user_handle, user_name, user_display_name
+        FROM passkey_credentials
+        WHERE user_handle = ?
+        "#,
+        user_handle
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| StoredCredential {
+            credential_id: row.credential_id.as_bytes().to_vec(),
+            public_key: row.public_key,
+            counter: row.counter as u32,
+            user: PublicKeyCredentialUserEntity {
+                user_handle: row.user_handle,
+                name: row.user_name,
+                display_name: row.user_display_name,
+            },
+        })
+        .collect())
+}
+
+async fn update_credential_counter_sqlite(
+    pool: &Pool<Sqlite>,
+    credential_id: &str,
+    counter: u32,
+) -> Result<(), PasskeyError> {
+    sqlx::query!(
+        r#"
+        UPDATE passkey_credentials
+        SET counter = ?, updated_at = CURRENT_TIMESTAMP
+        WHERE credential_id = ?
+        "#,
+        counter as i64,
+        credential_id
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(())
+}
+
+// PostgreSQL implementations
+async fn create_tables_postgres(pool: &Pool<Postgres>) -> Result<(), PasskeyError> {
+    sqlx::query!(
+        r#"
+        CREATE TABLE IF NOT EXISTS passkey_credentials (
+            credential_id TEXT PRIMARY KEY NOT NULL,
+            public_key BYTEA NOT NULL,
+            counter INTEGER NOT NULL DEFAULT 0,
+            user_handle TEXT NOT NULL,
+            user_name TEXT NOT NULL,
+            user_display_name TEXT NOT NULL,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(())
+}
+
+async fn store_credential_postgres(
+    pool: &Pool<Postgres>,
+    credential_id: &str,
+    credential: &StoredCredential,
+) -> Result<(), PasskeyError> {
+    sqlx::query!(
+        r#"
+        INSERT INTO passkey_credentials 
+        (credential_id, public_key, counter, user_handle, user_name, user_display_name, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP)
+        ON CONFLICT (credential_id) DO UPDATE
+        SET public_key = EXCLUDED.public_key,
+            counter = EXCLUDED.counter,
+            user_handle = EXCLUDED.user_handle,
+            user_name = EXCLUDED.user_name,
+            user_display_name = EXCLUDED.user_display_name,
+            updated_at = CURRENT_TIMESTAMP
+        "#,
+        credential_id,
+        &credential.public_key as &[u8],
+        credential.counter as i32,
+        &credential.user.user_handle,
+        &credential.user.name,
+        &credential.user.display_name,
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(())
+}
+
+async fn get_credential_postgres(
+    pool: &Pool<Postgres>,
+    credential_id: &str,
+) -> Result<Option<StoredCredential>, PasskeyError> {
+    let result = sqlx::query!(
+        r#"
+        SELECT public_key, counter, user_handle, user_name, user_display_name
+        FROM passkey_credentials
+        WHERE credential_id = $1
+        "#,
+        credential_id
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(result.map(|row| StoredCredential {
+        credential_id: credential_id.as_bytes().to_vec(),
+        public_key: row.public_key,
+        counter: row.counter as u32,
+        user: PublicKeyCredentialUserEntity {
+            user_handle: row.user_handle,
+            name: row.user_name,
+            display_name: row.user_display_name,
+        },
+    }))
+}
+
+async fn get_credentials_by_user_postgres(
+    pool: &Pool<Postgres>,
+    user_handle: &str,
+) -> Result<Vec<StoredCredential>, PasskeyError> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT credential_id, public_key, counter, user_handle, user_name, user_display_name
+        FROM passkey_credentials
+        WHERE user_handle = $1
+        "#,
+        user_handle
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| StoredCredential {
+            credential_id: row.credential_id.as_bytes().to_vec(),
+            public_key: row.public_key,
+            counter: row.counter as u32,
+            user: PublicKeyCredentialUserEntity {
+                user_handle: row.user_handle,
+                name: row.user_name,
+                display_name: row.user_display_name,
+            },
+        })
+        .collect())
+}
+
+async fn update_credential_counter_postgres(
+    pool: &Pool<Postgres>,
+    credential_id: &str,
+    counter: u32,
+) -> Result<(), PasskeyError> {
+    sqlx::query!(
+        r#"
+        UPDATE passkey_credentials
+        SET counter = $1, updated_at = CURRENT_TIMESTAMP
+        WHERE credential_id = $2
+        "#,
+        counter as i32,
+        credential_id
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| PasskeyError::Storage(e.to_string()))?;
+
+    Ok(())
+}

--- a/libpasskey/src/storage/mod.rs
+++ b/libpasskey/src/storage/mod.rs
@@ -1,3 +1,4 @@
+mod generic_data_store;
 mod memory;
 mod postgres;
 mod redis;
@@ -10,3 +11,8 @@ pub(crate) use types::{
     CacheStoreType, ChallengeStoreType, CredentialStoreType, InMemoryCacheStore,
     InMemoryChallengeStore, InMemoryCredentialStore,
 };
+
+// Re-export the new generic data store implementation
+// pub use generic_data_store::CredentialStore as GenericCredentialStore;
+
+pub use generic_data_store::PasskeyStore;

--- a/libstorage/Cargo.toml
+++ b/libstorage/Cargo.toml
@@ -12,5 +12,19 @@ serde_json = "1.0.139"
 thiserror = "2.0.11"
 tokio = { workspace = true }
 tracing = "0.1.41"
+sqlx = { version = "0.8", features = [
+    "any",
+    "chrono", 
+    "json", 
+    "macros",
+    "mysql", 
+    "postgres", 
+    "regexp", 
+    "runtime-tokio", 
+    "runtime-tokio-native-tls", 
+    "runtime-tokio-rustls", 
+    "sqlite",
+    "runtime-async-std-native-tls"
+], default-features = false }
 
 libsession = { workspace = true }

--- a/libstorage/docs/DATA_STORE.md
+++ b/libstorage/docs/DATA_STORE.md
@@ -1,0 +1,165 @@
+# Data Store Implementation Guide
+
+This document explains the design and implementation of the database abstraction layer in `libstorage`.
+
+## Overview
+
+The data store implementation provides a type-safe, efficient way to work with different database backends (currently SQLite and PostgreSQL) while maintaining a clean and minimal API.
+
+## Core Components
+
+### 1. DataStore Trait
+
+```rust
+pub trait DataStore: Send + Sync {
+    fn as_sqlite(&self) -> Option<&Pool<Sqlite>>;
+    fn as_postgres(&self) -> Option<&Pool<Postgres>>;
+}
+```
+
+This trait is the primary interface for database interactions. It:
+- Provides type-safe access to database pools
+- Allows database-specific operations when needed
+- Maintains thread safety with `Send + Sync`
+
+### 2. Store Types
+
+```rust
+pub(crate) struct SqliteDataStore {
+    pub(super) pool: sqlx::SqlitePool,
+}
+
+pub(crate) struct PostgresDataStore {
+    pub(super) pool: sqlx::PgPool,
+}
+```
+
+Each database type has its own struct that:
+- Encapsulates the database-specific pool
+- Implements the `DataStore` trait
+- Provides type safety at compile time
+
+### 3. Global Store
+
+```rust
+pub static GENERIC_DATA_STORE: LazyLock<Mutex<Box<dyn DataStore>>> = ...
+```
+
+A global store instance that:
+- Initializes lazily on first use
+- Provides thread-safe access via `Mutex`
+- Configures via environment variables
+
+## Configuration
+
+The store is configured through environment variables:
+
+1. `GENERIC_DATA_STORE_TYPE`: Database type ("sqlite" or "postgres")
+   - Default: "sqlite"
+
+2. `GENERIC_DATA_STORE_URL`: Database connection URL
+   - Default for SQLite: "sqlite:file:memdb1?mode=memory&cache=shared"
+   - Default for Postgres: "postgres://postgres:postgres@localhost:5432/postgres"
+
+## Usage Example
+
+```rust
+async fn example(store: &Box<dyn DataStore>) -> Result<(), Error> {
+    // Generic operations (work on any database)
+    let users = query_users(store).await?;
+
+    // Database-specific operations
+    if let Some(sqlite) = store.as_sqlite() {
+        // SQLite-specific code
+        sqlx::query("PRAGMA journal_mode = WAL")
+            .execute(sqlite)
+            .await?;
+    } else if let Some(postgres) = store.as_postgres() {
+        // Postgres-specific code
+        sqlx::query("SET synchronous_commit = off")
+            .execute(postgres)
+            .await?;
+    }
+
+    Ok(())
+}
+```
+
+## Design Decisions
+
+1. **Type Safety**
+   - Each database has its own type
+   - No runtime type casting needed
+   - Compile-time guarantees
+
+2. **Minimal API**
+   - Single trait for all databases
+   - Only necessary methods exposed
+   - Implementation details hidden
+
+3. **Efficiency**
+   - Lazy initialization
+   - No unnecessary abstractions
+   - Direct pool access when needed
+
+4. **Thread Safety**
+   - Global store protected by `Mutex`
+   - All types implement `Send + Sync`
+   - Safe concurrent access
+
+## Adding New Database Types
+
+To add support for a new database:
+
+1. Create a new store type:
+   ```rust
+   pub(crate) struct NewDbStore {
+       pub(super) pool: sqlx::NewDbPool,
+   }
+   ```
+
+2. Implement the `DataStore` trait:
+   ```rust
+   impl DataStore for NewDbStore {
+       fn as_sqlite(&self) -> Option<&Pool<Sqlite>> { None }
+       fn as_postgres(&self) -> Option<&Pool<Postgres>> { None }
+       // Add new method if needed:
+       // fn as_newdb(&self) -> Option<&Pool<NewDb>> { Some(&self.pool) }
+   }
+   ```
+
+3. Update the store initialization logic in `GENERIC_DATA_STORE`
+
+## Best Practices
+
+1. **Generic Operations**
+   - Use the `DataStore` trait for database-agnostic code
+   - Handle both database types in generic functions
+   - Use common SQL features when possible
+
+2. **Database-Specific Operations**
+   - Use `as_sqlite()` or `as_postgres()` for specific features
+   - Keep database-specific code isolated
+   - Document when specific features are required
+
+3. **Error Handling**
+   - Use proper error types and propagation
+   - Provide clear error messages
+   - Handle both generic and database-specific errors
+
+## Future Considerations
+
+1. **Additional Databases**
+   - Design allows easy addition of new databases
+   - Trait can be extended with new methods
+   - Minimal impact on existing code
+
+2. **Performance**
+   - Connection pooling already implemented
+   - Lazy initialization reduces startup cost
+   - Direct pool access for optimal performance
+
+3. **Maintenance**
+   - Clear separation of concerns
+   - Type-safe implementations
+   - Minimal code to maintain

--- a/libstorage/examples/store_usage.rs
+++ b/libstorage/examples/store_usage.rs
@@ -1,0 +1,75 @@
+use libstorage::{DataStore, GENERIC_DATA_STORE, GENERIC_DATA_STORE_TYPE, GENERIC_DATA_STORE_URL};
+use sqlx::Error as SqlxError;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Store type is determined by environment variables:
+    // GENERIC_DATA_STORE_TYPE=sqlite|postgres
+    // GENERIC_DATA_STORE_URL=<connection string>
+    println!("Using store type: {}", *GENERIC_DATA_STORE_TYPE);
+    println!("Using store URL: {}", *GENERIC_DATA_STORE_URL);
+
+    // Get access to the store
+    let store = GENERIC_DATA_STORE.lock().await;
+
+    // Example: Database-specific migrations
+    migrate_if_needed(&store).await?;
+
+    // Example: Generic query that works on both databases
+    let count = execute_generic_query(&store).await?;
+    println!("Count: {}", count);
+
+    Ok(())
+}
+
+async fn migrate_if_needed(store: &Box<dyn DataStore>) -> Result<(), SqlxError> {
+    if let Some(sqlite) = store.as_sqlite() {
+        // SQLite-specific migration
+        sqlx::query("PRAGMA journal_mode = WAL")
+            .execute(sqlite)
+            .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL
+            )",
+        )
+        .execute(sqlite)
+        .await?;
+    } else if let Some(postgres) = store.as_postgres() {
+        // Postgres-specific migration
+        sqlx::query("SET synchronous_commit = off")
+            .execute(postgres)
+            .await?;
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS users (
+                id SERIAL PRIMARY KEY,
+                name TEXT NOT NULL
+            )",
+        )
+        .execute(postgres)
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn execute_generic_query(store: &Box<dyn DataStore>) -> Result<i64, SqlxError> {
+    // This function works with both SQLite and Postgres
+    // because it uses common SQL features
+    let count = if let Some(sqlite) = store.as_sqlite() {
+        sqlx::query_scalar("SELECT COUNT(*) FROM users")
+            .fetch_one(sqlite)
+            .await?
+    } else if let Some(postgres) = store.as_postgres() {
+        sqlx::query_scalar("SELECT COUNT(*) FROM users")
+            .fetch_one(postgres)
+            .await?
+    } else {
+        return Err(SqlxError::Configuration("Unknown database type".into()));
+    };
+
+    Ok(count)
+}

--- a/libstorage/src/data/mod.rs
+++ b/libstorage/src/data/mod.rs
@@ -1,0 +1,77 @@
+use sqlx::{Pool, Postgres, Sqlite};
+use std::{env, sync::LazyLock};
+use tokio::sync::Mutex;
+
+// Types
+#[derive(Clone, Debug)]
+pub(crate) struct SqliteDataStore {
+    pub(super) pool: sqlx::SqlitePool,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct PostgresDataStore {
+    pub(super) pool: sqlx::PgPool,
+}
+
+// Trait
+pub trait DataStore: Send + Sync {
+    fn as_sqlite(&self) -> Option<&Pool<Sqlite>>;
+    fn as_postgres(&self) -> Option<&Pool<Postgres>>;
+}
+
+// Store implementations
+impl DataStore for SqliteDataStore {
+    fn as_sqlite(&self) -> Option<&Pool<Sqlite>> {
+        Some(&self.pool)
+    }
+
+    fn as_postgres(&self) -> Option<&Pool<Postgres>> {
+        None
+    }
+}
+
+impl DataStore for PostgresDataStore {
+    fn as_sqlite(&self) -> Option<&Pool<Sqlite>> {
+        None
+    }
+
+    fn as_postgres(&self) -> Option<&Pool<Postgres>> {
+        Some(&self.pool)
+    }
+}
+
+// Configuration
+const DEFAULT_SQLITE_STORE_URL: &str = "sqlite:file:memdb1?mode=memory&cache=shared";
+const DEFAULT_POSTGRES_STORE_URL: &str = "postgres://postgres:postgres@localhost:5432/postgres";
+
+pub static GENERIC_DATA_STORE_TYPE: LazyLock<String> =
+    LazyLock::new(|| env::var("GENERIC_DATA_STORE_TYPE").unwrap_or_else(|_| "sqlite".to_string()));
+
+pub static GENERIC_DATA_STORE_URL: LazyLock<String> = LazyLock::new(|| {
+    env::var("GENERIC_DATA_STORE_URL").unwrap_or_else(|_| match GENERIC_DATA_STORE_TYPE.as_str() {
+        "postgres" => DEFAULT_POSTGRES_STORE_URL.to_string(),
+        _ => DEFAULT_SQLITE_STORE_URL.to_string(),
+    })
+});
+
+pub static GENERIC_DATA_STORE: LazyLock<Mutex<Box<dyn DataStore>>> = LazyLock::new(|| {
+    let store = match GENERIC_DATA_STORE_TYPE.as_str() {
+        "sqlite" => Box::new(SqliteDataStore {
+            pool: sqlx::SqlitePool::connect_lazy(&GENERIC_DATA_STORE_URL)
+                .expect("Failed to create SQLite pool"),
+        }) as Box<dyn DataStore>,
+        "postgres" => Box::new(PostgresDataStore {
+            pool: sqlx::PgPool::connect_lazy(&GENERIC_DATA_STORE_URL)
+                .expect("Failed to create Postgres pool"),
+        }) as Box<dyn DataStore>,
+        t => panic!(
+            "Unsupported store type: {}. Supported types are 'sqlite' and 'postgres'",
+            t
+        ),
+    };
+    tracing::info!(
+        "Initializing data store with type: {}",
+        GENERIC_DATA_STORE_TYPE.as_str()
+    );
+    Mutex::new(store)
+});

--- a/libstorage/src/errors.rs
+++ b/libstorage/src/errors.rs
@@ -5,6 +5,9 @@ pub enum StorageError {
     #[error("Configuration error: {0}")]
     Config(String),
 
+    #[error("Connection error: {0}")]
+    Connection(String),
+
     #[error("Storage error: {0}")]
     Storage(String),
 

--- a/libstorage/src/lib.rs
+++ b/libstorage/src/lib.rs
@@ -1,4 +1,5 @@
 mod cache;
+mod data;
 mod errors;
 mod types;
 
@@ -12,3 +13,5 @@ pub async fn init() -> Result<(), errors::StorageError> {
 pub use cache::GENERIC_CACHE_STORE;
 pub use cache::init_cache_store;
 pub use types::CacheData;
+
+pub use data::{DataStore, GENERIC_DATA_STORE, GENERIC_DATA_STORE_TYPE, GENERIC_DATA_STORE_URL};


### PR DESCRIPTION
This commit introduces a major refactoring of the credential storage system:

1. Core Changes:
- Introduce PasskeyStore for unified credential storage operations
- Migrate from in-memory store to generic data store (SQLite/PostgreSQL)
- Add proper schema for credential storage with timestamps
- Improve error handling with specific error types

2. Authentication Improvements:
- Add proper user handle verification based on credential type
- Implement counter verification to prevent replay attacks
- Add debug logging for credential properties
- Fix error messages to be more specific

3. Code Organization:
- Keep AuthenticatorData struct in types.rs with implementation in auth.rs
- Add detailed documentation for WebAuthn flags
- Clean up imports and formatting
- Remove unused credential store initialization

This change provides better persistence, security, and maintainability while keeping the API minimal and clean.