### PR TITLE
refactor: separate libsession initialization from liboauth2

### DIFF
--- a/demo-integration/Cargo.toml
+++ b/demo-integration/Cargo.toml
@@ -14,6 +14,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 liboauth2 = { workspace = true }
 libpasskey = { workspace = true }
 libaxum = { workspace = true }
+libsession = { workspace = true }
 
 axum = { workspace = true }
 tokio = { workspace = true }

--- a/demo-integration/src/main.rs
+++ b/demo-integration/src/main.rs
@@ -70,6 +70,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize the OAuth2 library
     liboauth2::init().await?;
+    libsession::init().await?;
     libpasskey::init().await?;
 
     let app = Router::new()

--- a/demo-oauth2/Cargo.toml
+++ b/demo-oauth2/Cargo.toml
@@ -16,3 +16,4 @@ rustls = { workspace = true }
 
 libaxum = { workspace = true }
 liboauth2 = { workspace = true }
+libsession = { workspace = true }

--- a/demo-oauth2/src/main.rs
+++ b/demo-oauth2/src/main.rs
@@ -32,6 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize the OAuth2 library
     liboauth2::init().await?;
+    libsession::init().await?;
 
     let app = Router::new()
         .route("/", get(index))

--- a/liboauth2/Cargo.toml
+++ b/liboauth2/Cargo.toml
@@ -27,9 +27,11 @@ sha2 = "0.10.8"
 base64 = "0.22.1"
 tracing = "0.1.41"
 
-libsession = { workspace = true }
 axum = { workspace = true }
 chrono = { workspace = true }
+
+libsession = { workspace = true }
+libstorage = { workspace = true }
 
 [package.metadata.askama]
 dir = "templates"

--- a/liboauth2/src/common.rs
+++ b/liboauth2/src/common.rs
@@ -1,15 +1,16 @@
-use anyhow::Context;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE};
 use chrono::{DateTime, Utc};
 use http::header::{HeaderMap, SET_COOKIE};
 use ring::rand::SecureRandom;
 
-use crate::errors::AppError;
+use crate::errors::OAuth2Error;
+use crate::types::StoredToken;
 
-pub(crate) fn gen_random_string(len: usize) -> Result<String, AppError> {
+pub(crate) fn gen_random_string(len: usize) -> Result<String, OAuth2Error> {
     let rng = ring::rand::SystemRandom::new();
     let mut session_id = vec![0u8; len];
-    rng.fill(&mut session_id)?;
+    rng.fill(&mut session_id)
+        .map_err(|_| OAuth2Error::Crypto("Failed to generate random string".to_string()))?;
     Ok(URL_SAFE.encode(session_id))
 }
 
@@ -19,13 +20,31 @@ pub fn header_set_cookie(
     value: String,
     _expires_at: DateTime<Utc>,
     max_age: i64,
-) -> Result<&HeaderMap, AppError> {
+) -> Result<&HeaderMap, OAuth2Error> {
     let cookie =
         format!("{name}={value}; SameSite=Lax; Secure; HttpOnly; Path=/; Max-Age={max_age}");
     println!("Cookie: {:#?}", cookie);
     headers.append(
         SET_COOKIE,
-        cookie.parse().context("failed to parse cookie")?,
+        cookie
+            .parse()
+            .map_err(|_| OAuth2Error::Cookie("Failed to parse cookie".to_string()))?,
     );
     Ok(headers)
+}
+
+impl From<StoredToken> for libstorage::CacheData {
+    fn from(data: StoredToken) -> Self {
+        Self {
+            value: serde_json::to_vec(&data).expect("Failed to serialize StoredToken"),
+        }
+    }
+}
+
+impl TryFrom<libstorage::CacheData> for StoredToken {
+    type Error = OAuth2Error;
+
+    fn try_from(data: libstorage::CacheData) -> Result<Self, Self::Error> {
+        serde_json::from_slice(&data.value).map_err(|e| OAuth2Error::Storage(e.to_string()))
+    }
 }

--- a/liboauth2/src/config.rs
+++ b/liboauth2/src/config.rs
@@ -1,13 +1,5 @@
 use std::{env, sync::LazyLock};
-use tokio::sync::Mutex;
 
-use crate::errors::AppError;
-use crate::storage::{CacheStoreToken, InMemoryTokenStore};
-
-use crate::types::TokenStoreType;
-
-// static OAUTH2_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
-// static OAUTH2_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
 pub(crate) static OAUTH2_USERINFO_URL: &str = "https://www.googleapis.com/userinfo/v2/me";
 
 pub static OAUTH2_AUTH_URL: LazyLock<String> = LazyLock::new(|| {
@@ -83,85 +75,3 @@ pub(crate) static OAUTH2_GOOGLE_CLIENT_ID: LazyLock<String> = LazyLock::new(|| {
 pub(crate) static OAUTH2_GOOGLE_CLIENT_SECRET: LazyLock<String> = LazyLock::new(|| {
     std::env::var("OAUTH2_GOOGLE_CLIENT_SECRET").expect("OAUTH2_GOOGLE_CLIENT_SECRET must be set")
 });
-
-/// A wrapper type that ensures the token store can only be set once
-pub(crate) struct SingletonStore {
-    store: Box<dyn CacheStoreToken>,
-    initialized: bool,
-}
-
-impl SingletonStore {
-    fn new(store: Box<dyn CacheStoreToken>) -> Self {
-        Self {
-            store,
-            initialized: false,
-        }
-    }
-
-    /// Set the store implementation. This can only be done once.
-    /// Returns an error if attempting to set the store after it's already been initialized.
-    fn set_store(&mut self, new_store: Box<dyn CacheStoreToken>) -> Result<(), AppError> {
-        if self.initialized {
-            return Err(AppError(anyhow::anyhow!(
-                "Token store has already been initialized"
-            )));
-        }
-        self.store = new_store;
-        self.initialized = true;
-        Ok(())
-    }
-
-    /// Get a reference to the underlying store
-    pub(crate) fn get_store(&self) -> &dyn CacheStoreToken {
-        &*self.store
-    }
-
-    /// Get a mutable reference to the underlying store, but only for operations
-    /// defined in the CacheStoreToken trait
-    pub(crate) fn get_store_mut(&mut self) -> &mut Box<dyn CacheStoreToken> {
-        &mut self.store
-    }
-}
-
-/// Global singleton for token storage. This follows a pattern where:
-/// 1. We initialize with a safe default (InMemoryTokenStore) when the library is first loaded
-/// 2. The actual implementation (Memory or Redis) is determined at runtime in init_token_store()
-/// 3. We use SingletonStore to ensure the implementation can only be set once
-///
-/// Type structure:
-/// ```text
-/// static TOKEN_STORE: LazyLock<Mutex<SingletonStore>>
-///     |                |      |    |
-///     |                |      |    +-- Wrapper that ensures one-time initialization
-///     |                |      +------- Thread-safe interior mutability
-///     |                +-------------- Lazy initialization
-///     +-------------------------------- Static lifetime
-/// ```
-///
-/// Note on mutability:
-/// - The store implementation can only be set once through SingletonStore::set_store
-/// - Attempts to set the store after initialization will result in an error
-/// - The Mutex ensures thread-safe access to store operations
-pub(crate) static TOKEN_STORE: LazyLock<Mutex<SingletonStore>> =
-    LazyLock::new(|| Mutex::new(SingletonStore::new(Box::new(InMemoryTokenStore::new()))));
-
-/// Initialize the token store based on environment configuration.
-/// This will:
-/// 1. Check environment variables for store configuration (OAUTH2_TOKEN_STORE, OAUTH2_TOKEN_REDIS_URL)
-/// 2. Create the appropriate store implementation (Memory or Redis)
-/// 3. Replace the default in-memory store in TOKEN_STORE with the configured implementation
-///
-/// Initialize the token store based on environment configuration
-pub async fn init_token_store() -> Result<(), AppError> {
-    let store_type = TokenStoreType::from_env().unwrap_or_else(|e| {
-        eprintln!("Failed to initialize token store from environment: {}", e);
-        eprintln!("Falling back to in-memory store");
-        TokenStoreType::Memory
-    });
-
-    tracing::info!("Initializing token store with type: {:?}", store_type);
-    let store = store_type.create_store().await?;
-    TOKEN_STORE.lock().await.set_store(store)?;
-    tracing::info!("Token store initialized successfully");
-    Ok(())
-}

--- a/liboauth2/src/errors.rs
+++ b/liboauth2/src/errors.rs
@@ -47,12 +47,6 @@ impl From<std::num::TryFromIntError> for AppError {
     }
 }
 
-impl From<libsession::AppError> for AppError {
-    fn from(err: libsession::AppError) -> Self {
-        Self(anyhow::anyhow!("Session error: {}", err))
-    }
-}
-
 impl From<crate::oauth2::TokenVerificationError> for AppError {
     fn from(err: crate::oauth2::TokenVerificationError) -> Self {
         Self(anyhow::anyhow!("Token verification error: {:?}", err))

--- a/liboauth2/src/errors.rs
+++ b/liboauth2/src/errors.rs
@@ -1,60 +1,112 @@
-// Use anyhow, define error and enable '?'
-// For a simplified example of using anyhow in axum check /examples/anyhow-error-response
-#[derive(Debug)]
-pub struct AppError(pub(crate) anyhow::Error);
+// // Use anyhow, define error and enable '?'
+// // For a simplified example of using anyhow in axum check /examples/anyhow-error-response
+// #[derive(Debug)]
+// pub struct AppError(pub(crate) anyhow::Error);
 
-impl std::fmt::Display for AppError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
+// impl std::fmt::Display for AppError {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         write!(f, "{}", self.0)
+//     }
+// }
 
-// This enables using `?` on functions that return `Result<_, anyhow::Error>` to turn them into
-// `Result<_, AppError>`. That way you don't need to do that manually.
-impl From<anyhow::Error> for AppError {
-    fn from(err: anyhow::Error) -> Self {
-        Self(err)
-    }
-}
+// // This enables using `?` on functions that return `Result<_, anyhow::Error>` to turn them into
+// // `Result<_, AppError>`. That way you don't need to do that manually.
+// impl From<anyhow::Error> for AppError {
+//     fn from(err: anyhow::Error) -> Self {
+//         Self(err)
+//     }
+// }
 
-impl From<redis::RedisError> for AppError {
-    fn from(err: redis::RedisError) -> Self {
-        Self(err.into())
-    }
-}
+// impl From<redis::RedisError> for AppError {
+//     fn from(err: redis::RedisError) -> Self {
+//         Self(err.into())
+//     }
+// }
 
-impl From<serde_json::Error> for AppError {
-    fn from(err: serde_json::Error) -> Self {
-        Self(err.into())
-    }
-}
+// impl From<serde_json::Error> for AppError {
+//     fn from(err: serde_json::Error) -> Self {
+//         Self(err.into())
+//     }
+// }
 
-impl From<std::env::VarError> for AppError {
-    fn from(err: std::env::VarError) -> Self {
-        Self(err.into())
-    }
-}
+// impl From<std::env::VarError> for AppError {
+//     fn from(err: std::env::VarError) -> Self {
+//         Self(err.into())
+//     }
+// }
 
-impl From<ring::error::Unspecified> for AppError {
-    fn from(err: ring::error::Unspecified) -> Self {
-        Self(anyhow::anyhow!("Ring error: {:?}", err))
-    }
-}
+// impl From<ring::error::Unspecified> for AppError {
+//     fn from(err: ring::error::Unspecified) -> Self {
+//         Self(anyhow::anyhow!("Ring error: {:?}", err))
+//     }
+// }
 
-impl From<std::num::TryFromIntError> for AppError {
-    fn from(err: std::num::TryFromIntError) -> Self {
-        Self(err.into())
-    }
-}
+// impl From<std::num::TryFromIntError> for AppError {
+//     fn from(err: std::num::TryFromIntError) -> Self {
+//         Self(err.into())
+//     }
+// }
 
-impl From<crate::oauth2::TokenVerificationError> for AppError {
-    fn from(err: crate::oauth2::TokenVerificationError) -> Self {
-        Self(anyhow::anyhow!("Token verification error: {:?}", err))
-    }
-}
+// impl From<crate::oauth2::TokenVerificationError> for AppError {
+//     fn from(err: crate::oauth2::TokenVerificationError) -> Self {
+//         Self(anyhow::anyhow!("Token verification error: {:?}", err))
+//     }
+// }
 
-impl std::error::Error for AppError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(self.0.as_ref())
-    }
+// impl std::error::Error for AppError {
+//     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+//         Some(self.0.as_ref())
+//     }
+// }
+
+use thiserror::Error;
+#[derive(Debug, Error, Clone)]
+pub enum OAuth2Error {
+    #[error("Storage error: {0}")]
+    Storage(String),
+
+    #[error("Crypto error: {0}")]
+    Crypto(String),
+
+    #[error("Cookie error: {0}")]
+    Cookie(String),
+
+    #[error("Id mismatch")]
+    IdMismatch,
+
+    #[error("Serde error: {0}")]
+    Serde(String),
+
+    #[error("Security token not found: {0}")]
+    SecurityTokenNotFound(String),
+
+    #[error("Nonce expired")]
+    NonceExpired,
+
+    #[error("Nonce mismatch")]
+    NonceMismatch,
+
+    #[error("Csrf token mismatch")]
+    CsrfTokenMismatch,
+
+    #[error("Csrf token expired")]
+    CsrfTokenExpired,
+
+    #[error("User agent mismatch")]
+    UserAgentMismatch,
+
+    #[error("Id token error: {0}")]
+    IdToken(String),
+
+    #[error("Invalid origin: {0}")]
+    InvalidOrigin(String),
+
+    #[error("Decode state error: {0}")]
+    DecodeState(String),
+
+    #[error("Fetch user info error: {0}")]
+    FetchUserInfo(String),
+
+    #[error("Token exchange error: {0}")]
+    TokenExchange(String),
 }

--- a/liboauth2/src/lib.rs
+++ b/liboauth2/src/lib.rs
@@ -16,27 +16,6 @@ pub use config::{OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME};
 pub use oauth2::{csrf_checks, get_idinfo_userinfo, prepare_oauth2_auth_request, validate_origin};
 pub use types::AuthResponse;
 
-/// Initialize the OAuth2 library.
-///
-/// This function must be called before using the library. It:
-/// 1. Initializes the token store singleton based on environment configuration
-/// 2. Initializes the session store singleton
-/// 3. Initializes the user store singleton
-///
-/// # Errors
-/// Returns an error if any store initialization fails.
-///
-/// # Example
-/// ```no_run
-/// use liboauth2;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     // Initialize stores before using the library
-///     liboauth2::init().await?;
-///     Ok(())
-/// }
-/// ```
 pub async fn init() -> Result<(), errors::AppError> {
     // Validate required environment variables early
     let _ = *config::OAUTH2_REDIRECT_URI; // This will validate ORIGIN
@@ -44,6 +23,5 @@ pub async fn init() -> Result<(), errors::AppError> {
     let _ = *config::OAUTH2_GOOGLE_CLIENT_SECRET;
 
     config::init_token_store().await?;
-    libsession::init().await?;
     Ok(())
 }

--- a/liboauth2/src/lib.rs
+++ b/liboauth2/src/lib.rs
@@ -4,7 +4,6 @@ mod common;
 mod config;
 mod errors;
 mod oauth2;
-mod storage;
 mod types;
 
 // Re-export only what's necessary for the public API
@@ -16,12 +15,11 @@ pub use config::{OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME};
 pub use oauth2::{csrf_checks, get_idinfo_userinfo, prepare_oauth2_auth_request, validate_origin};
 pub use types::AuthResponse;
 
-pub async fn init() -> Result<(), errors::AppError> {
+pub async fn init() -> Result<(), errors::OAuth2Error> {
     // Validate required environment variables early
     let _ = *config::OAUTH2_REDIRECT_URI; // This will validate ORIGIN
     let _ = *config::OAUTH2_GOOGLE_CLIENT_ID;
     let _ = *config::OAUTH2_GOOGLE_CLIENT_SECRET;
 
-    config::init_token_store().await?;
     Ok(())
 }

--- a/liboauth2/src/oauth2/core.rs
+++ b/liboauth2/src/oauth2/core.rs
@@ -1,9 +1,5 @@
-use anyhow::Context;
 use headers::Cookie;
 use http::header::HeaderMap;
-
-// use http::HeaderValue;
-// use tower_http::cors::CorsLayer;
 
 use base64::{
     Engine as _,
@@ -14,13 +10,15 @@ use url::Url;
 use chrono::{DateTime, Duration, Utc};
 use sha2::{Digest, Sha256};
 
+use libstorage::GENERIC_CACHE_STORE;
+
 use crate::common::{gen_random_string, header_set_cookie};
 use crate::config::{
     OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_MAX_AGE, OAUTH2_CSRF_COOKIE_NAME, OAUTH2_GOOGLE_CLIENT_ID,
     OAUTH2_GOOGLE_CLIENT_SECRET, OAUTH2_QUERY_STRING, OAUTH2_REDIRECT_URI, OAUTH2_TOKEN_URL,
-    OAUTH2_USERINFO_URL, TOKEN_STORE,
+    OAUTH2_USERINFO_URL,
 };
-use crate::errors::AppError;
+use crate::errors::OAuth2Error;
 use crate::oauth2::idtoken::{IdInfo as GoogleIdInfo, verify_idtoken};
 use crate::types::{AuthResponse, GoogleUserInfo, OidcTokenResponse, StateParams, StoredToken};
 
@@ -36,9 +34,10 @@ pub fn encode_state(csrf_token: String, nonce_id: String, pkce_id: String) -> St
 }
 
 pub async fn generate_store_token(
+    token_type: &str,
     expires_at: DateTime<Utc>,
     user_agent: Option<String>,
-) -> Result<(String, String), AppError> {
+) -> Result<(String, String), OAuth2Error> {
     let token = gen_random_string(32)?;
     let token_id = gen_random_string(32)?;
 
@@ -49,34 +48,37 @@ pub async fn generate_store_token(
         ttl: *OAUTH2_CSRF_COOKIE_MAX_AGE,
     };
 
-    TOKEN_STORE
+    GENERIC_CACHE_STORE
         .lock()
         .await
         .get_store_mut()
-        .put(&token_id, token_data.clone())
-        .await?;
+        .put(token_type, &token_id, token_data.into())
+        .await
+        .map_err(|e| OAuth2Error::Storage(e.to_string()))?;
 
     Ok((token, token_id))
 }
 
 pub async fn prepare_oauth2_auth_request(
     headers: HeaderMap,
-) -> Result<(String, HeaderMap), AppError> {
+) -> Result<(String, HeaderMap), OAuth2Error> {
     let expires_at = Utc::now() + Duration::seconds((*OAUTH2_CSRF_COOKIE_MAX_AGE) as i64);
     let user_agent = headers
         .get(axum::http::header::USER_AGENT)
         .and_then(|h| h.to_str().ok())
         .unwrap_or("Unknown")
         .to_string();
-    let (csrf_token, csrf_id) = generate_store_token(expires_at, Some(user_agent)).await?;
-    let (nonce_token, nonce_id) = generate_store_token(expires_at, None).await?;
-    let (pkce_token, pkce_id) = generate_store_token(expires_at, None).await?;
-    #[cfg(debug_assertions)]
-    println!("PKCE ID: {:?}, PKCE verifier: {:?}", pkce_id, pkce_token);
+
+    let (csrf_token, csrf_id) = generate_store_token("csrf", expires_at, Some(user_agent)).await?;
+    let (nonce_token, nonce_id) = generate_store_token("nonce", expires_at, None).await?;
+    let (pkce_token, pkce_id) = generate_store_token("pkce", expires_at, None).await?;
+
+    tracing::debug!("PKCE ID: {:?}, PKCE verifier: {:?}", pkce_id, pkce_token);
     let pkce_challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(pkce_token.as_bytes()));
-    #[cfg(debug_assertions)]
-    println!("PKCE Challenge: {:#?}", pkce_challenge);
+
+    tracing::debug!("PKCE Challenge: {:#?}", pkce_challenge);
     let encoded_state = encode_state(csrf_token, nonce_id, pkce_id);
+
     let auth_url = format!(
         "{}?{}&client_id={}&redirect_uri={}&state={}&nonce={}\
         &code_challenge={}&code_challenge_method={}",
@@ -89,8 +91,9 @@ pub async fn prepare_oauth2_auth_request(
         pkce_challenge,
         "S256"
     );
-    #[cfg(debug_assertions)]
-    println!("Auth URL: {:#?}", auth_url);
+
+    tracing::debug!("Auth URL: {:#?}", auth_url);
+
     let mut headers = HeaderMap::new();
     header_set_cookie(
         &mut headers,
@@ -98,96 +101,112 @@ pub async fn prepare_oauth2_auth_request(
         csrf_id,
         expires_at,
         *OAUTH2_CSRF_COOKIE_MAX_AGE as i64,
-    )?;
+    )
+    .map_err(|e| OAuth2Error::Cookie(e.to_string()))?;
+
+    tracing::debug!("Headers: {:#?}", headers);
+
     Ok((auth_url, headers))
 }
 
 pub async fn get_idinfo_userinfo(
     auth_response: &AuthResponse,
-) -> Result<(GoogleIdInfo, GoogleUserInfo), AppError> {
+) -> Result<(GoogleIdInfo, GoogleUserInfo), OAuth2Error> {
     let pkce_verifier = get_pkce_verifier(auth_response).await?;
     let (access_token, id_token) =
         exchange_code_for_token(auth_response.code.clone(), pkce_verifier).await?;
 
-    let idinfo = verify_idtoken(id_token, OAUTH2_GOOGLE_CLIENT_ID.to_string()).await?;
+    let idinfo = verify_idtoken(id_token, OAUTH2_GOOGLE_CLIENT_ID.to_string())
+        .await
+        .map_err(|e| OAuth2Error::IdToken(e.to_string()))?;
+
     verify_nonce(auth_response, idinfo.clone()).await?;
 
     let userinfo = fetch_user_data_from_google(access_token).await?;
 
     if idinfo.sub != userinfo.id {
-        println!(
+        tracing::error!(
             "Id mismatch in IdInfo and Userinfo: \nIdInfo: {:#?}\nUserInfo: {:#?}",
-            idinfo, userinfo
+            idinfo,
+            userinfo
         );
-        return Err(anyhow::anyhow!("ID mismatch").into());
+        return Err(OAuth2Error::IdMismatch);
     }
     Ok((idinfo, userinfo))
 }
 
-async fn get_pkce_verifier(auth_response: &AuthResponse) -> Result<String, AppError> {
+async fn get_pkce_verifier(auth_response: &AuthResponse) -> Result<String, OAuth2Error> {
     let decoded_state_string =
         String::from_utf8(URL_SAFE.decode(&auth_response.state).unwrap()).unwrap();
-    let state_in_response: StateParams = serde_json::from_str(&decoded_state_string)?;
+    let state_in_response: StateParams = serde_json::from_str(&decoded_state_string)
+        .map_err(|e| OAuth2Error::Serde(e.to_string()))?;
 
-    let pkce_session = TOKEN_STORE
+    let pkce_session: StoredToken = GENERIC_CACHE_STORE
         .lock()
         .await
         .get_store()
-        .get(&state_in_response.pkce_id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("PKCE Session not found"))?;
+        .get("pkce", &state_in_response.pkce_id)
+        .await
+        .map_err(|e| OAuth2Error::Storage(e.to_string()))?
+        .ok_or_else(|| OAuth2Error::SecurityTokenNotFound("PKCE Session not found".to_string()))?
+        .try_into()?;
 
-    TOKEN_STORE
+    GENERIC_CACHE_STORE
         .lock()
         .await
         .get_store_mut()
-        .remove(&state_in_response.pkce_id)
+        .remove("pkce", &state_in_response.pkce_id)
         .await
-        .expect("Failed to remove PKCE session");
-
+        .map_err(|e| OAuth2Error::Storage(e.to_string()))?;
     let pkce_verifier = pkce_session.token.clone();
-    println!("PKCE Verifier: {:#?}", pkce_verifier);
+    tracing::debug!("PKCE Verifier: {:#?}", pkce_verifier);
     Ok(pkce_verifier)
 }
 
-async fn verify_nonce(auth_response: &AuthResponse, idinfo: GoogleIdInfo) -> Result<(), AppError> {
+async fn verify_nonce(
+    auth_response: &AuthResponse,
+    idinfo: GoogleIdInfo,
+) -> Result<(), OAuth2Error> {
     let decoded_state_string =
         String::from_utf8(URL_SAFE.decode(&auth_response.state).unwrap()).unwrap();
-    let state_in_response: StateParams = serde_json::from_str(&decoded_state_string)?;
+    let state_in_response: StateParams = serde_json::from_str(&decoded_state_string)
+        .map_err(|e| OAuth2Error::Serde(e.to_string()))?;
 
-    let nonce_session = TOKEN_STORE
+    let nonce_session: StoredToken = GENERIC_CACHE_STORE
         .lock()
         .await
         .get_store()
-        .get(&state_in_response.nonce_id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Nonce Session not found"))?;
+        .get("nonce", &state_in_response.nonce_id)
+        .await
+        .map_err(|e| OAuth2Error::Storage(e.to_string()))?
+        .ok_or_else(|| OAuth2Error::SecurityTokenNotFound("Nonce Session not found".to_string()))?
+        .try_into()?;
 
-    println!("Nonce Data: {:#?}", nonce_session);
+    tracing::debug!("Nonce Data: {:#?}", nonce_session);
 
     if Utc::now() > nonce_session.expires_at {
-        println!("Nonce Expired: {:#?}", nonce_session.expires_at);
-        println!("Now: {:#?}", Utc::now());
-        return Err(anyhow::anyhow!("Nonce expired").into());
+        tracing::error!("Nonce Expired: {:#?}", nonce_session.expires_at);
+        tracing::error!("Now: {:#?}", Utc::now());
+        return Err(OAuth2Error::NonceExpired);
     }
     if idinfo.nonce != Some(nonce_session.token.clone()) {
-        println!("Nonce in ID Token: {:#?}", idinfo.nonce);
-        println!("Stored Nonce: {:#?}", nonce_session.token);
-        return Err(anyhow::anyhow!("Nonce mismatch").into());
+        tracing::error!("Nonce in ID Token: {:#?}", idinfo.nonce);
+        tracing::error!("Stored Nonce: {:#?}", nonce_session.token);
+        return Err(OAuth2Error::NonceMismatch);
     }
 
-    TOKEN_STORE
+    GENERIC_CACHE_STORE
         .lock()
         .await
         .get_store_mut()
-        .remove(&state_in_response.nonce_id)
+        .remove("nonce", &state_in_response.nonce_id)
         .await
         .expect("Failed to remove nonce session");
 
     Ok(())
 }
 
-pub async fn validate_origin(headers: &HeaderMap, auth_url: &str) -> Result<(), AppError> {
+pub async fn validate_origin(headers: &HeaderMap, auth_url: &str) -> Result<(), OAuth2Error> {
     let parsed_url = Url::parse(auth_url).expect("Invalid URL");
     let scheme = parsed_url.scheme();
     let host = parsed_url.host_str().unwrap_or_default();
@@ -204,9 +223,12 @@ pub async fn validate_origin(headers: &HeaderMap, auth_url: &str) -> Result<(), 
     match origin {
         Some(origin) if origin.starts_with(&expected_origin) => Ok(()),
         _ => {
-            println!("Expected Origin: {:#?}", expected_origin);
-            println!("Actual Origin: {:#?}", origin);
-            Err(anyhow::anyhow!("Invalid origin").into())
+            tracing::error!("Expected Origin: {:#?}", expected_origin);
+            tracing::error!("Actual Origin: {:#?}", origin);
+            Err(OAuth2Error::InvalidOrigin(format!(
+                "Expected Origin: {:#?}, Actual Origin: {:#?}",
+                expected_origin, origin
+            )))
         }
     }
 }
@@ -215,25 +237,32 @@ pub async fn csrf_checks(
     cookies: Cookie,
     query: &AuthResponse,
     headers: HeaderMap,
-) -> Result<(), AppError> {
+) -> Result<(), OAuth2Error> {
     let csrf_id = cookies
         .get(OAUTH2_CSRF_COOKIE_NAME.as_str())
-        .ok_or_else(|| anyhow::anyhow!("No CSRF session cookie found"))?;
-    let csrf_session = TOKEN_STORE
+        .ok_or_else(|| {
+            OAuth2Error::SecurityTokenNotFound("No CSRF session cookie found".to_string())
+        })?;
+
+    let csrf_session: StoredToken = GENERIC_CACHE_STORE
         .lock()
         .await
         .get_store()
-        .get(csrf_id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("CSRF Session not found in Session Store"))?;
+        .get("csrf", csrf_id)
+        .await
+        .map_err(|e| OAuth2Error::Storage(e.to_string()))?
+        .ok_or_else(|| OAuth2Error::SecurityTokenNotFound("CSRF Session not found".to_string()))?
+        .try_into()?;
 
-    TOKEN_STORE
+    tracing::debug!("CSRF Session: {:#?}", csrf_session);
+
+    GENERIC_CACHE_STORE
         .lock()
         .await
         .get_store_mut()
-        .remove(csrf_id)
+        .remove("csrf", csrf_id)
         .await
-        .expect("Failed to remove PKCE session");
+        .map_err(|e| OAuth2Error::Storage(e.to_string()))?;
 
     let user_agent = headers
         .get(axum::http::header::USER_AGENT)
@@ -244,67 +273,66 @@ pub async fn csrf_checks(
     let decoded_state_string = String::from_utf8(
         URL_SAFE
             .decode(&query.state)
-            .map_err(|e| anyhow::anyhow!("Failed to decode state: {e}"))?,
+            .map_err(|e| OAuth2Error::DecodeState(e.to_string()))?,
     )
-    .context("Failed to convert decoded state to string")?;
+    .map_err(|e| OAuth2Error::DecodeState(e.to_string()))?;
 
     let state_in_response: StateParams = serde_json::from_str(&decoded_state_string)
-        .context("Failed to deserialize state from response")?;
+        .map_err(|e| OAuth2Error::Serde(e.to_string()))?;
 
     if state_in_response.csrf_token != csrf_session.token {
-        println!(
+        tracing::error!(
             "CSRF Token in state param: {:#?}",
             state_in_response.csrf_token
         );
-        println!("Stored CSRF Token: {:#?}", csrf_session.token);
-        return Err(anyhow::anyhow!("CSRF token mismatch").into());
+        tracing::error!("Stored CSRF Token: {:#?}", csrf_session.token);
+        return Err(OAuth2Error::CsrfTokenMismatch);
     }
 
     if Utc::now() > csrf_session.expires_at {
-        println!("Now: {}", Utc::now());
-        println!("CSRF Expires At: {:#?}", csrf_session.expires_at);
-        return Err(anyhow::anyhow!("CSRF token expired").into());
+        tracing::error!("Now: {}", Utc::now());
+        tracing::error!("CSRF Expires At: {:#?}", csrf_session.expires_at);
+        return Err(OAuth2Error::CsrfTokenExpired);
     }
 
     if user_agent != csrf_session.user_agent.clone().unwrap_or_default() {
-        println!("User Agent: {:#?}", user_agent);
-        println!(
+        tracing::error!("User Agent: {:#?}", user_agent);
+        tracing::error!(
             "Stored User Agent: {:#?}",
             csrf_session.user_agent.unwrap_or_default()
         );
-        return Err(anyhow::anyhow!("User agent mismatch").into());
+        return Err(OAuth2Error::UserAgentMismatch);
     }
 
     Ok(())
 }
 
-async fn fetch_user_data_from_google(access_token: String) -> Result<GoogleUserInfo, AppError> {
+async fn fetch_user_data_from_google(access_token: String) -> Result<GoogleUserInfo, OAuth2Error> {
     let client = crate::client::get_client();
     let response = client
         .get(OAUTH2_USERINFO_URL)
         .bearer_auth(access_token)
         .send()
         .await
-        .context("failed in sending request to target Url")?;
+        .map_err(|e| OAuth2Error::FetchUserInfo(e.to_string()))?;
+
     let response_body = response
         .text()
         .await
-        .context("failed to get response body")?;
-    #[cfg(debug_assertions)]
-    println!("Response Body: {:#?}", response_body);
-    let user_data: GoogleUserInfo = serde_json::from_str(&response_body).context(format!(
-        "Failed to deserialize response body: {}",
-        response_body
-    ))?;
-    #[cfg(debug_assertions)]
-    println!("User data: {:#?}", user_data);
+        .map_err(|e| OAuth2Error::FetchUserInfo(e.to_string()))?;
+
+    tracing::debug!("Response Body: {:#?}", response_body);
+    let user_data: GoogleUserInfo = serde_json::from_str(&response_body)
+        .map_err(|e| OAuth2Error::Serde(format!("Failed to deserialize response body: {}", e)))?;
+
+    tracing::debug!("User data: {:#?}", user_data);
     Ok(user_data)
 }
 
 async fn exchange_code_for_token(
     code: String,
     code_verifier: String,
-) -> Result<(String, String), AppError> {
+) -> Result<(String, String), OAuth2Error> {
     let client = crate::client::get_client();
     let response = client
         .post(OAUTH2_TOKEN_URL.as_str())
@@ -318,26 +346,27 @@ async fn exchange_code_for_token(
         ])
         .send()
         .await
-        .context("failed in sending request request to authorization server")?;
+        .map_err(|e| OAuth2Error::TokenExchange(e.to_string()))?;
 
     match response.status() {
         reqwest::StatusCode::OK => {
-            println!("Debug Token Exchange Response: {:#?}", response);
+            tracing::debug!("Token Exchange Response: {:#?}", response);
         }
         status => {
-            println!("Token Exchange Response: {:#?}", response);
-            return Err(anyhow::anyhow!("Unexpected status code: {:#?}", status).into());
+            tracing::debug!("Token Exchange Response: {:#?}", response);
+            return Err(OAuth2Error::TokenExchange(status.to_string()));
         }
     };
 
     let response_body = response
         .text()
         .await
-        .context("failed to get response body")?;
-    let response_json: OidcTokenResponse =
-        serde_json::from_str(&response_body).context("failed to deserialize response body")?;
+        .map_err(|e| OAuth2Error::TokenExchange(e.to_string()))?;
+    let response_json: OidcTokenResponse = serde_json::from_str(&response_body)
+        .map_err(|e| OAuth2Error::TokenExchange(e.to_string()))?;
     let access_token = response_json.access_token.clone();
     let id_token = response_json.id_token.clone().unwrap();
-    println!("Response JSON: {:#?}", response_json);
+
+    tracing::debug!("Response JSON: {:#?}", response_json);
     Ok((access_token, id_token))
 }

--- a/liboauth2/src/oauth2/idtoken.rs
+++ b/liboauth2/src/oauth2/idtoken.rs
@@ -303,12 +303,10 @@ pub async fn verify_idtoken(
             "kid".to_string(),
         ))?;
     let alg = header.alg;
-
-    println!("Algorithm from JWT header: {:?}", alg);
-
     let idinfo: IdInfo = decode_token(&token)?;
-    #[cfg(debug_assertions)]
-    println!("Decoded id_token payload: {:#?}", idinfo);
+
+    tracing::debug!("Algorithm from JWT header: {:?}", alg);
+    tracing::debug!("Decoded id_token payload: {:#?}", idinfo);
 
     let jwks_url = "https://www.googleapis.com/oauth2/v3/certs";
     let jwks = fetch_jwks(jwks_url).await?;

--- a/liboauth2/src/oauth2/mod.rs
+++ b/liboauth2/src/oauth2/mod.rs
@@ -2,4 +2,4 @@ mod core;
 mod idtoken;
 
 pub use core::{csrf_checks, get_idinfo_userinfo, prepare_oauth2_auth_request, validate_origin};
-pub(crate) use idtoken::{IdInfo, TokenVerificationError};
+pub(crate) use idtoken::IdInfo;

--- a/liboauth2/src/types.rs
+++ b/liboauth2/src/types.rs
@@ -91,11 +91,3 @@ pub(crate) struct OidcTokenResponse {
     scope: String,
     pub(crate) id_token: Option<String>,
 }
-
-#[derive(Clone, Debug)]
-pub enum TokenStoreType {
-    Memory,
-    Sqlite { url: String },
-    Postgres { url: String },
-    Redis { url: String },
-}

--- a/libstorage/Cargo.toml
+++ b/libstorage/Cargo.toml
@@ -26,5 +26,3 @@ sqlx = { version = "0.8", features = [
     "sqlite",
     "runtime-async-std-native-tls"
 ], default-features = false }
-
-libsession = { workspace = true }


### PR DESCRIPTION
- Move session initialization responsibility from liboauth2 to client applications
- Add explicit libsession::init() calls in demo applications
- Add libsession as a direct dependency in demo applications
- Remove libsession dependency from libstorage
- Remove unused From<libsession::AppError> implementation in liboauth2
- Simplify liboauth2::init() documentation and implementation