### PR TITLE
refactor: Move core functions to libauth crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ thiserror = "2.0.12"
 serde_json = "1.0.140"
 serde = { version = "1.0.218", features = ["derive"] }
 uuid = { version = "1.15", features = ["v4"] }
+urlencoding = "2.1.3"
 
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite", "postgres", "chrono", "json", "uuid"] }
 

--- a/clear_db_cache.sh
+++ b/clear_db_cache.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#DB_STRING="psql postgres://passkey:passkey@localhost:5432/passkey"
+DB_STRING="sqlite3 /tmp/sqlite.db"
+
+echo "drop table users"| $DB_STRING
+echo "drop table passkey_credentials"| $DB_STRING
+redis-cli flushall
+

--- a/clear_db_cache.sh
+++ b/clear_db_cache.sh
@@ -5,5 +5,5 @@ DB_STRING="sqlite3 /tmp/sqlite.db"
 
 echo "drop table users"| $DB_STRING
 echo "drop table passkey_credentials"| $DB_STRING
+echo "drop table oauth2_accounts"| $DB_STRING
 redis-cli flushall
-

--- a/demo-integration/src/handlers.rs
+++ b/demo-integration/src/handlers.rs
@@ -33,7 +33,7 @@ struct ProtectedTemplate<'a> {
 pub(crate) async fn index(user: Option<User>) -> Result<Html<String>, (StatusCode, String)> {
     match user {
         Some(u) => {
-            let message = format!("Hey {}!", u.id);
+            let message = format!("Hey {}!", u.name);
             let template = IndexTemplateUser {
                 // user: u,
                 message: &message,

--- a/demo-integration/src/main.rs
+++ b/demo-integration/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(debug_assertions)]
         {
             // Debug build default - show all log levels
-            "libaxum=trace,libsession=trace,libpasskey=trace,liboauth2=trace,libstorage=trace,libuserdb=trace,demo_integration=trace".into()
+            "libaxum=trace,libauth=trace,libsession=trace,libpasskey=trace,liboauth2=trace,libstorage=trace,libuserdb=trace,demo_integration=trace".into()
         }
 
         #[cfg(not(debug_assertions))]

--- a/demo-integration/templates/index_anon.j2
+++ b/demo-integration/templates/index_anon.j2
@@ -8,6 +8,7 @@
 
     <script src="{{auth_route_prefix}}/oauth2.js"></script>
     <script src="{{passkey_route_prefix}}/passkey.js"></script>
+    <script src="{{passkey_route_prefix}}/conditional_ui.js"></script>
     <script>
         const oauth2 = initOAuth2Popup();
         const AUTH_ROUTE_PREFIX = '{{auth_route_prefix}}';
@@ -21,20 +22,30 @@
         <h1>{{message}}</h1>
     </div>
     <div style="display: flex; gap: 10px; margin-top: 10px;">
-        <button onclick="oauth2.openPopup()">Google Oauth2</button>
+        Google OAuth2:
+    </div>
+    <div style="display: flex; gap: 10px; margin-top: 10px;">
+        <button onclick="oauth2.openPopup()">Create User or Sign in</button>
     </div>
 
     <div style="display: flex; gap: 10px; margin-top: 10px;">
-        <button onclick="startAuthentication(false)">Have Passkey?</button>
+        Passkey:
     </div>
     <div style="display: flex; gap: 10px; margin-top: 10px;">
         <button onclick="showRegistrationModal()">
-            Create New Account with Passkey
+            Create User
         </button>
-    </div>
-
-    <div>
-        <p>Or, <a href="{{passkey_route_prefix}}/conditional_ui">try conditional UI</a>.</p>
+        <button onclick="startAuthentication(false)">Sign in</button>
+        {# Or, <a href="{{passkey_route_prefix}}/conditional_ui">try conditional UI</a> #}
+    {# </div>
+    <div style="display: flex; gap: 10px; margin-top: 10px;"> #} 
+        <form id="signin-form">
+            <div class="form-group">
+                <label for="username-input">or try conditional UI</label>
+                <input type="email" id="username-input" name="username" autocomplete="username webauthn"
+                    placeholder="Enter your email" required>
+            </div>
+        </form>
     </div>
 
 </body>

--- a/demo-integration/templates/index_user.j2
+++ b/demo-integration/templates/index_user.j2
@@ -48,6 +48,7 @@
                 <p><a href="{{passkey_route_prefix}}/credentials">View your passkeys</a>.</p>
             </dd>
         </dl>
+        <button onclick="showRegistrationModal()">Add New Passkey</button>
     </div>
     <div class="user-accounts">
         <dl>
@@ -56,13 +57,7 @@
                 <p><a href="{{auth_route_prefix}}/accounts">View your OAuth2 accounts</a>.</p>
             </dd>
         </dl>
-    </div>
-    <div style="display: flex; gap: 10px; margin-top: 10px;">
-        <button onclick="showRegistrationModal()">Register New Passkey</button>
-    </div>
-
-    <div style="display: flex; gap: 10px; margin-top: 10px;">
-        <button onclick="oauth2.openPopup()">Link New OAuth2 Account</button>
+        <button onclick="oauth2.openPopup()">Add New OAuth2 Account</button>
     </div>
 
     <div style="display: flex; gap: 10px; margin-top: 10px;">

--- a/libauth/Cargo.toml
+++ b/libauth/Cargo.toml
@@ -11,9 +11,14 @@ liboauth2 = { path = "../liboauth2" }
 libpasskey = { path = "../libpasskey" }
 libuserdb = { path = "../libuserdb" }
 libstorage = { path = "../libstorage" }
-thiserror = "1.0"
-uuid = { version = "1.4", features = ["v4", "serde"] }
-chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1.0", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+libsession = { path = "../libsession" }
+
+chrono.workspace = true
+headers.workspace = true
+http.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+uuid.workspace = true

--- a/libauth/src/lib.rs
+++ b/libauth/src/lib.rs
@@ -5,12 +5,28 @@
 
 mod errors;
 mod oauth2_coordinator;
+mod oauth2_flow;
 mod passkey_coordinator;
+mod passkey_flow;
 
 // Re-export the main coordination components
 pub use errors::AuthError;
 pub use oauth2_coordinator::OAuth2Coordinator;
+pub use oauth2_flow::{
+    get_authorized_core, get_oauth2_accounts, list_accounts_core, post_authorized_core,
+    process_oauth2_authorization,
+};
 pub use passkey_coordinator::PasskeyCoordinator;
+pub use passkey_flow::{
+    handle_finish_authentication_core, handle_finish_registration_core,
+    handle_start_authentication_core, handle_start_registration_get_core,
+    handle_start_registration_post_core, list_credentials_core,
+};
+
+pub use liboauth2::{
+    AuthResponse, OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME, OAUTH2_ROUTE_PREFIX, OAuth2Account,
+    csrf_checks, prepare_oauth2_auth_request, validate_origin,
+};
 
 pub use libpasskey::{
     AuthenticationOptions, AuthenticatorResponse, PublicKeyCredentialUserEntity,
@@ -18,6 +34,8 @@ pub use libpasskey::{
     finish_registration_with_auth_user, gen_random_string, start_authentication,
     start_registration,
 };
+
+pub use libsession::prepare_logout_response;
 
 /// Initialize the authentication coordination layer
 pub async fn init() -> Result<(), AuthError> {

--- a/libauth/src/oauth2_coordinator.rs
+++ b/libauth/src/oauth2_coordinator.rs
@@ -40,6 +40,7 @@ impl OAuth2Coordinator {
         let user = if account.user_id.is_empty() {
             let new_user = User {
                 id: Uuid::new_v4().to_string(),
+                name: account.name.clone(),
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             };

--- a/libauth/src/oauth2_flow.rs
+++ b/libauth/src/oauth2_flow.rs
@@ -1,0 +1,206 @@
+use chrono::{Duration, Utc};
+use http::{HeaderMap, StatusCode};
+
+use liboauth2::{
+    AuthResponse, OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME, OAuth2Account, OAuth2Store,
+    csrf_checks, decode_state, delete_session_and_misc_token_from_store, get_idinfo_userinfo,
+    get_uid_from_stored_session_by_state_param, header_set_cookie, validate_origin,
+};
+use libsession::{User as SessionUser, create_session_with_uid};
+use libuserdb::{User as DbUser, UserStore};
+
+use crate::errors::AuthError;
+
+trait IntoResponseError<T> {
+    fn into_response_error(self) -> Result<T, (StatusCode, String)>;
+}
+
+impl<T, E: std::fmt::Display> IntoResponseError<T> for Result<T, E> {
+    fn into_response_error(self) -> Result<T, (StatusCode, String)> {
+        self.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
+    }
+}
+
+pub async fn get_authorized_core(
+    auth_response: &AuthResponse,
+    cookies: &headers::Cookie,
+    headers: &HeaderMap,
+) -> Result<HeaderMap, (StatusCode, String)> {
+    validate_origin(headers, OAUTH2_AUTH_URL.as_str())
+        .await
+        .into_response_error()?;
+
+    csrf_checks(cookies.clone(), auth_response, headers.clone())
+        .await
+        .into_response_error()?;
+
+    process_oauth2_authorization(auth_response).await
+}
+
+pub async fn post_authorized_core(
+    auth_response: &AuthResponse,
+    headers: &HeaderMap,
+) -> Result<HeaderMap, (StatusCode, String)> {
+    validate_origin(headers, OAUTH2_AUTH_URL.as_str())
+        .await
+        .into_response_error()?;
+
+    if auth_response.state.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Missing state parameter".to_string(),
+        ));
+    }
+
+    let headers = process_oauth2_authorization(auth_response).await?;
+
+    Ok(headers)
+}
+
+pub async fn list_accounts_core(
+    user: Option<&SessionUser>,
+) -> Result<Vec<OAuth2Account>, (StatusCode, String)> {
+    match user {
+        Some(user) => {
+            tracing::debug!("User: {:#?}", user);
+            OAuth2Store::get_oauth2_accounts(&user.id)
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
+        }
+        None => Err((StatusCode::BAD_REQUEST, "Not logged in!".to_string())),
+    }
+}
+
+pub async fn process_oauth2_authorization(
+    auth_response: &AuthResponse,
+) -> Result<HeaderMap, (StatusCode, String)> {
+    let (idinfo, userinfo) = get_idinfo_userinfo(auth_response)
+        .await
+        .into_response_error()?;
+
+    // Convert GoogleUserInfo to DbUser and store it
+    static OAUTH2_GOOGLE_USER: &str = "idinfo";
+
+    let mut oauth2_account = match OAUTH2_GOOGLE_USER {
+        "idinfo" => OAuth2Account::from(idinfo),
+        "userinfo" => OAuth2Account::from(userinfo),
+        _ => OAuth2Account::from(idinfo), // Default case
+    };
+
+    // Upsert oauth2_account and user
+    // 1. Decode the state from the auth response
+    // 2. Extract user_id from the stored session if available
+    // 3. Check if the OAuth2 account exists
+
+    // Handle user and account linking
+    // 4. If user is logged in and account exists, ensure they match
+    // 5. If user is logged in but account doesn't exist, link account to user
+    // 6. If user is not logged in but account exists, create session for account
+    // 7. If neither user is logged in nor account exists, create new user and account
+
+    // Create session with user_id
+    // 8. Create a new entry in session store
+    // 9. Create a header for the session cookie
+
+    // Decode the state from the auth response
+    let state_in_response =
+        decode_state(&auth_response.state).map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    // Extract user_id from the stored session if available
+    let state_user_id = get_uid_from_stored_session_by_state_param(&state_in_response)
+        .await
+        .into_response_error()?;
+
+    // Check if the OAuth2 account exists
+    let stored_oauth2_account = OAuth2Store::get_oauth2_account_by_provider(
+        &oauth2_account.provider,
+        &oauth2_account.provider_user_id,
+    )
+    .await
+    .into_response_error()?;
+
+    // Match on the combination of auth_user and existing_account
+    let user_id: String = match (state_user_id, stored_oauth2_account) {
+        // Case 1: User is logged in and account exists
+        (Some(state_user_id), Some(stored_oauth2_account)) => {
+            if state_user_id == stored_oauth2_account.user_id {
+                tracing::debug!("OAuth2 account already linked to current user");
+                // Nothing to do, account is already properly linked
+            } else {
+                tracing::debug!("OAuth2 account already linked to different user");
+                // return Err((StatusCode::BAD_REQUEST, "This OAuth2 account is already linked to a different user".to_string()));
+            }
+            delete_session_and_misc_token_from_store(&state_in_response)
+                .await
+                .into_response_error()?;
+            state_user_id.to_string()
+        }
+        // Case 2: User is logged in but account doesn't exist
+        (Some(state_user_id), None) => {
+            tracing::debug!("Linking OAuth2 account to user {}", state_user_id);
+            oauth2_account.user_id = state_user_id.clone();
+            OAuth2Store::upsert_oauth2_account(oauth2_account)
+                .await
+                .into_response_error()?;
+            delete_session_and_misc_token_from_store(&state_in_response)
+                .await
+                .into_response_error()?;
+            state_user_id.to_string()
+        }
+        // Case 3: User is not logged in but account exists
+        (None, Some(stored_oauth2_account)) => {
+            tracing::debug!("Using existing account's user");
+            stored_oauth2_account.user_id
+        }
+        // Case 4: User is not logged in and account doesn't exist
+        (None, None) => {
+            tracing::debug!("Creating new user and account");
+            #[allow(clippy::let_and_return)]
+            let user_id = create_user_and_oauth2account(oauth2_account)
+                .await
+                .into_response_error()?;
+            user_id
+        }
+    };
+
+    let mut headers = renew_session_header(user_id).await?;
+
+    let _ = header_set_cookie(
+        &mut headers,
+        OAUTH2_CSRF_COOKIE_NAME.to_string(),
+        "value".to_string(),
+        Utc::now() - Duration::seconds(86400),
+        -86400,
+    )
+    .into_response_error()?;
+
+    Ok(headers)
+}
+
+async fn renew_session_header(user_id: String) -> Result<HeaderMap, (StatusCode, String)> {
+    let headers = create_session_with_uid(&user_id)
+        .await
+        .into_response_error()?;
+    Ok(headers)
+}
+
+async fn create_user_and_oauth2account(
+    mut oauth2_account: OAuth2Account,
+) -> Result<String, AuthError> {
+    let new_user = DbUser {
+        id: uuid::Uuid::new_v4().to_string(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    };
+    let stored_user = UserStore::upsert_user(new_user).await?;
+    oauth2_account.user_id = stored_user.id.clone();
+    OAuth2Store::upsert_oauth2_account(oauth2_account).await?;
+    Ok(stored_user.id)
+}
+
+/// Get all OAuth2 accounts for a user
+pub async fn get_oauth2_accounts(user_id: &str) -> Result<Vec<OAuth2Account>, AuthError> {
+    OAuth2Store::get_oauth2_accounts(user_id)
+        .await
+        .map_err(AuthError::OAuth2)
+}

--- a/libauth/src/passkey_coordinator.rs
+++ b/libauth/src/passkey_coordinator.rs
@@ -27,8 +27,12 @@ impl PasskeyCoordinator {
     pub async fn create_user_then_finish_registration(
         reg_data: libpasskey::RegisterCredential,
     ) -> Result<String, AuthError> {
+        // Get user name from registration data with fallback mechanism
+        let name = reg_data.get_user_name().await;
+
         let new_user = User {
             id: Uuid::new_v4().to_string(),
+            name,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -61,6 +65,7 @@ impl PasskeyCoordinator {
                 // User doesn't exist, so we should create one
                 let new_user = User {
                     id: user_id.to_string(),
+                    name: "Passkey User".to_string(), // Default name since we don't have reg_data here
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
                 };

--- a/libauth/src/passkey_flow.rs
+++ b/libauth/src/passkey_flow.rs
@@ -3,16 +3,15 @@ use http::{HeaderMap, StatusCode};
 use serde_json::Value;
 use uuid::Uuid;
 
-use libuserdb::{User, UserStore};
+use liboauth2::OAuth2Store;
 use libpasskey::{
     AuthenticationOptions, AuthenticatorResponse, CredentialSearchField, PasskeyStore,
     RegisterCredential, RegistrationOptions, StoredCredential, finish_authentication,
-    finish_registration, finish_registration_with_auth_user, start_authentication, start_registration,
+    finish_registration, finish_registration_with_auth_user, start_authentication,
+    start_registration,
 };
 use libsession::{User as SessionUser, create_session_with_uid};
-use liboauth2::OAuth2Store;
-
-
+use libuserdb::{User, UserStore};
 
 /// Core function that handles the business logic of starting registration with OAuth2 account info
 ///

--- a/libauth/src/passkey_flow.rs
+++ b/libauth/src/passkey_flow.rs
@@ -99,9 +99,14 @@ pub async fn handle_finish_registration_core(
             Ok((HeaderMap::new(), message))
         }
         None => {
+            // Get user name from registration data with fallback mechanism
+            let name = reg_data.get_user_name().await;
+            tracing::debug!("User name: {}, registration data: {:#?}", name, reg_data);
+
             // Create a new user for unauthenticated registration
             let new_user = User {
                 id: Uuid::new_v4().to_string(),
+                name,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             };

--- a/libauth/src/passkey_flow.rs
+++ b/libauth/src/passkey_flow.rs
@@ -1,0 +1,200 @@
+use chrono::Utc;
+use http::{HeaderMap, StatusCode};
+use serde_json::Value;
+use uuid::Uuid;
+
+use libuserdb::{User, UserStore};
+use libpasskey::{
+    AuthenticationOptions, AuthenticatorResponse, CredentialSearchField, PasskeyStore,
+    RegisterCredential, RegistrationOptions, StoredCredential, finish_authentication,
+    finish_registration, finish_registration_with_auth_user, start_authentication, start_registration,
+};
+use libsession::{User as SessionUser, create_session_with_uid};
+use liboauth2::OAuth2Store;
+
+
+
+/// Core function that handles the business logic of starting registration with OAuth2 account info
+///
+/// This function takes an optional reference to a SessionUser and returns registration options
+/// based on the user's OAuth2 account information.
+pub async fn handle_start_registration_get_core(
+    user: Option<&SessionUser>,
+) -> Result<RegistrationOptions, (StatusCode, String)> {
+    match user {
+        None => Err((StatusCode::BAD_REQUEST, "Not logged in!".to_string())),
+        Some(user) => {
+            tracing::debug!("User: {:#?}", user);
+
+            // Get the user's OAuth2 accounts
+            let oauth2_accounts = OAuth2Store::get_oauth2_accounts(&user.id)
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?
+                .first()
+                .cloned()
+                .ok_or_else(|| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        "No OAuth2 accounts found".to_string(),
+                    )
+                })?;
+
+            // Extract username and displayname from the OAuth2 account
+            let username = oauth2_accounts.email.clone();
+            let displayname = oauth2_accounts.name.clone();
+
+            // Start registration with the extracted information
+            start_registration(Some(user.clone()), username, displayname)
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
+        }
+    }
+}
+
+/// Core function that handles the business logic of starting registration with provided user info
+///
+/// This function takes an optional reference to a SessionUser, extracts username and displayname
+/// from the request body, and returns registration options.
+pub async fn handle_start_registration_post_core(
+    auth_user: Option<&SessionUser>,
+    body: &Value,
+) -> Result<RegistrationOptions, (StatusCode, String)> {
+    // Extract username from the request body
+    let username = body
+        .get("username")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or((StatusCode::BAD_REQUEST, "Missing username".to_string()))?;
+
+    // Extract displayname from the request body, defaulting to username if not provided
+    let displayname = body
+        .get("displayname")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or(username.clone());
+
+    // Call the start_registration function with the extracted data
+    start_registration(auth_user.cloned(), username, displayname)
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
+}
+
+/// Core function that handles the business logic of finishing registration
+///
+/// This function takes an optional reference to a SessionUser and registration data,
+/// and either registers a new credential for an existing user or creates a new user
+/// with the credential.
+pub async fn handle_finish_registration_core(
+    auth_user: Option<&SessionUser>,
+    reg_data: RegisterCredential,
+) -> Result<(HeaderMap, String), (StatusCode, String)> {
+    match auth_user {
+        Some(session_user) => {
+            tracing::debug!("User: {:#?}", session_user);
+
+            // Handle authenticated user registration
+            let message = finish_registration_with_auth_user(session_user.clone(), reg_data)
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+            Ok((HeaderMap::new(), message))
+        }
+        None => {
+            // Create a new user for unauthenticated registration
+            let new_user = User {
+                id: Uuid::new_v4().to_string(),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            };
+
+            // Store the user
+            let stored_user = UserStore::upsert_user(new_user)
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+            // Finish registration
+            let result = finish_registration(&stored_user.id, &reg_data)
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()));
+
+            match result {
+                Ok(message) => {
+                    // Create session with the user_id
+                    let headers = create_session_with_uid(&stored_user.id)
+                        .await
+                        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+                    Ok((headers, message))
+                }
+                Err(err) => Err(err),
+            }
+        }
+    }
+}
+
+/// Core function that handles the business logic of starting authentication
+///
+/// This function extracts the username from the request body and starts the
+/// authentication process.
+pub async fn handle_start_authentication_core(
+    body: &Value,
+) -> Result<AuthenticationOptions, (StatusCode, String)> {
+    // Extract username from the request body
+    let username = if body.is_object() {
+        body.get("username")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+    } else if body.is_string() {
+        Some(body.as_str().unwrap().to_string()) // Directly use the string
+    } else {
+        None
+    };
+
+    // Start the authentication process
+    start_authentication(username).await.map_err(|e| {
+        tracing::debug!("Error: {:#?}", e);
+        (StatusCode::BAD_REQUEST, e.to_string())
+    })
+}
+
+/// Core function that handles the business logic of finishing authentication
+///
+/// This function verifies the authentication response, creates a session for the
+/// authenticated user, and returns the user ID, name, and session headers.
+pub async fn handle_finish_authentication_core(
+    auth_response: AuthenticatorResponse,
+) -> Result<(String, String, HeaderMap), (StatusCode, String)> {
+    tracing::debug!("Auth response: {:#?}", auth_response);
+
+    // Verify the authentication and get the user ID and name
+    let (uid, name) = finish_authentication(auth_response)
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    tracing::debug!("User ID: {:#?}", uid);
+
+    // Create a session for the authenticated user
+    let headers = create_session_with_uid(&uid)
+        .await
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    Ok((uid, name, headers))
+}
+
+/// Core function that handles the business logic of listing passkey credentials
+///
+/// This function takes an optional reference to a SessionUser and returns the list of stored credentials
+/// associated with that user, or an error if the user is not logged in.
+pub async fn list_credentials_core(
+    user: Option<&SessionUser>,
+) -> Result<Vec<StoredCredential>, (StatusCode, String)> {
+    match user {
+        Some(user) => {
+            tracing::debug!("User: {:#?}", user);
+            PasskeyStore::get_credentials_by(CredentialSearchField::UserId(user.id.to_owned()))
+                .await
+                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
+        }
+        None => Err((StatusCode::BAD_REQUEST, "Not logged in!".to_string())),
+    }
+}

--- a/libaxum/Cargo.toml
+++ b/libaxum/Cargo.toml
@@ -19,3 +19,4 @@ axum = { workspace = true }
 axum-extra = { workspace = true }
 chrono = { workspace = true }
 serde_json = { workspace = true }
+urlencoding = { workspace = true }

--- a/libaxum/src/oauth2/handlers.rs
+++ b/libaxum/src/oauth2/handlers.rs
@@ -42,15 +42,18 @@ pub fn router() -> Router {
 
 #[derive(Template)]
 #[template(path = "popup_close.j2")]
-struct PopupCloseTemplate{
+struct PopupCloseTemplate {
     message: String,
 }
 
-pub(crate) async fn popup_close(Query(params): Query<HashMap<String, String>>) -> Result<Html<String>, (StatusCode, String)> {
-    let message = params.get("message").cloned().unwrap_or_else(|| "Authentication completed".to_string());
-    let template = PopupCloseTemplate {
-        message,
-    };
+pub(crate) async fn popup_close(
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Html<String>, (StatusCode, String)> {
+    let message = params
+        .get("message")
+        .cloned()
+        .unwrap_or_else(|| "Authentication completed".to_string());
+    let template = PopupCloseTemplate { message };
     let html = Html(template.render().into_response_error()?);
     Ok(html)
 }
@@ -92,7 +95,11 @@ pub async fn get_authorized(
 
     Ok((
         headers,
-        Redirect::to(&format!("{}/popup_close?message={}", OAUTH2_ROUTE_PREFIX.as_str(), urlencoding::encode(&message))),
+        Redirect::to(&format!(
+            "{}/popup_close?message={}",
+            OAUTH2_ROUTE_PREFIX.as_str(),
+            urlencoding::encode(&message)
+        )),
     ))
 }
 
@@ -113,7 +120,11 @@ pub async fn post_authorized(
 
     Ok((
         headers,
-        Redirect::to(&format!("{}/popup_close?message={}", OAUTH2_ROUTE_PREFIX.as_str(), urlencoding::encode(&message))),
+        Redirect::to(&format!(
+            "{}/popup_close?message={}",
+            OAUTH2_ROUTE_PREFIX.as_str(),
+            urlencoding::encode(&message)
+        )),
     ))
 }
 

--- a/libaxum/src/passkey/handlers.rs
+++ b/libaxum/src/passkey/handlers.rs
@@ -13,11 +13,10 @@ use libauth::{
     handle_start_registration_post_core, list_credentials_core,
 };
 
-use libpasskey::{StoredCredential, PASSKEY_ROUTE_PREFIX};
+use libpasskey::{PASSKEY_ROUTE_PREFIX, StoredCredential};
 use libsession::User as SessionUser;
 
 use crate::session::AuthUser;
-
 
 /// Axum handler that extracts AuthUser from the request and delegates to the core function
 pub(crate) async fn handle_start_registration_get(
@@ -34,7 +33,6 @@ pub(crate) async fn handle_start_registration_get(
     Ok(Json(options))
 }
 
-
 pub(crate) async fn handle_start_registration_post(
     auth_user: Option<AuthUser>,
     Json(body): Json<Value>,
@@ -50,7 +48,6 @@ pub(crate) async fn handle_start_registration_post(
     Json(registration_options)
 }
 
-
 pub(crate) async fn handle_finish_registration(
     auth_user: Option<AuthUser>,
     Json(reg_data): Json<RegisterCredential>,
@@ -61,7 +58,6 @@ pub(crate) async fn handle_finish_registration(
     handle_finish_registration_core(session_user, reg_data).await
 }
 
-
 pub(crate) async fn handle_start_authentication(
     Json(body): Json<Value>,
 ) -> Result<Json<AuthenticationOptions>, (StatusCode, String)> {
@@ -71,7 +67,6 @@ pub(crate) async fn handle_start_authentication(
     // Return the authentication options as JSON
     Ok(Json(auth_options))
 }
-
 
 pub(crate) async fn handle_finish_authentication(
     Json(auth_response): Json<AuthenticatorResponse>,
@@ -113,7 +108,6 @@ pub(crate) async fn serve_conditional_ui_js() -> Response {
         .body(js_content.to_string().into())
         .unwrap()
 }
-
 
 /// Axum handler that extracts AuthUser from the request and delegates to the core function
 ///

--- a/libaxum/src/passkey/handlers.rs
+++ b/libaxum/src/passkey/handlers.rs
@@ -4,177 +4,82 @@ use axum::{
     http::{HeaderMap, StatusCode, header::CONTENT_TYPE},
     response::{Html, IntoResponse, Response},
 };
-use chrono::Utc;
 use serde_json::Value;
-use uuid::Uuid;
-
-use libuserdb::{User, UserStore};
 
 use libauth::{
     AuthenticationOptions, AuthenticatorResponse, RegisterCredential, RegistrationOptions,
-    finish_authentication, finish_registration, finish_registration_with_auth_user,
-    start_authentication, start_registration,
+    handle_finish_authentication_core, handle_finish_registration_core,
+    handle_start_authentication_core, handle_start_registration_get_core,
+    handle_start_registration_post_core, list_credentials_core,
 };
 
-use liboauth2::OAuth2Store;
-use libpasskey::{CredentialSearchField, PASSKEY_ROUTE_PREFIX, PasskeyStore, StoredCredential};
-use libsession::{User as SessionUser, create_session_with_uid};
+use libpasskey::{StoredCredential, PASSKEY_ROUTE_PREFIX};
+use libsession::User as SessionUser;
 
 use crate::session::AuthUser;
 
+
+/// Axum handler that extracts AuthUser from the request and delegates to the core function
 pub(crate) async fn handle_start_registration_get(
     user: Option<AuthUser>,
 ) -> Result<Json<RegistrationOptions>, (StatusCode, String)> {
-    match user {
-        None => Err((StatusCode::BAD_REQUEST, "Not logged in!".to_string())),
-        Some(u) => {
-            tracing::debug!("User: {:#?}", u);
+    // Convert AuthUser to SessionUser if present using deref coercion
+    let session_user = user.as_ref().map(|u| u as &SessionUser);
 
-            let session_user: SessionUser = (*u).clone();
+    // Call the core function with the extracted data
+    let options = handle_start_registration_get_core(session_user)
+        .await
+        .expect("Failed to start registration");
 
-            let oauth2_accounts = OAuth2Store::get_oauth2_accounts(&u.id)
-                // OAuth2Store::get_oauth2_accounts(&session_user.id)
-                .await
-                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?
-                .first()
-                .cloned()
-                .ok_or_else(|| {
-                    (
-                        StatusCode::BAD_REQUEST,
-                        "No OAuth2 accounts found".to_string(),
-                    )
-                })?;
-
-            let username = oauth2_accounts.email.clone();
-            let displayname = oauth2_accounts.name.clone();
-
-            let options = start_registration(Some(session_user), username, displayname)
-                .await
-                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
-                .expect("Failed to start registration");
-            Ok(Json(options))
-        }
-    }
+    Ok(Json(options))
 }
 
-pub(crate) async fn handle_start_registration(
+
+pub(crate) async fn handle_start_registration_post(
     auth_user: Option<AuthUser>,
     Json(body): Json<Value>,
 ) -> Json<RegistrationOptions> {
-    let session_user: Option<SessionUser> = match auth_user {
-        Some(u) => {
-            tracing::debug!("User: {:#?}", u);
+    // Convert AuthUser to SessionUser if present using deref coercion
+    let session_user = auth_user.as_ref().map(|u| u as &SessionUser);
 
-            let session_user: SessionUser = (*u).clone();
-            Some(session_user)
-        }
-        None => None,
-    };
+    // Call the core function with the extracted data
+    let registration_options = handle_start_registration_post_core(session_user, &body)
+        .await
+        .expect("Failed to start registration");
 
-    let username = body
-        .get("username")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .expect("Missing username");
-
-    let displayname = body
-        .get("displayname")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .unwrap_or(username.clone());
-
-    Json(
-        start_registration(session_user, username, displayname)
-            .await
-            .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))
-            .expect("Failed to start registration"),
-    )
+    Json(registration_options)
 }
+
 
 pub(crate) async fn handle_finish_registration(
     auth_user: Option<AuthUser>,
     Json(reg_data): Json<RegisterCredential>,
 ) -> Result<(HeaderMap, String), (StatusCode, String)> {
-    match auth_user {
-        Some(u) => {
-            tracing::debug!("User: {:#?}", u);
+    // Convert AuthUser to SessionUser if present
+    let session_user = auth_user.as_ref().map(|u| u as &SessionUser);
 
-            let session_user: SessionUser = (*u).clone();
-            let message = finish_registration_with_auth_user(session_user, reg_data)
-                .await
-                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
-
-            Ok((HeaderMap::new(), message))
-        }
-        None => {
-            let new_user = User {
-                id: Uuid::new_v4().to_string(),
-                created_at: Utc::now(),
-                updated_at: Utc::now(),
-            };
-
-            // Store the user
-            let stored_user = UserStore::upsert_user(new_user)
-                .await
-                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
-
-            // Finish registration
-            let result = finish_registration(&stored_user.id, &reg_data)
-                .await
-                .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()));
-
-            match result {
-                Ok(message) => {
-                    // Create session with the user_id
-                    let headers = create_session_with_uid(&stored_user.id)
-                        .await
-                        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
-
-                    Ok((headers, message))
-                }
-                Err(err) => Err(err),
-            }
-        }
-    }
+    handle_finish_registration_core(session_user, reg_data).await
 }
+
 
 pub(crate) async fn handle_start_authentication(
     Json(body): Json<Value>,
 ) -> Result<Json<AuthenticationOptions>, (StatusCode, String)> {
-    let username = if body.is_object() {
-        body.get("username")
-            .and_then(|v| v.as_str())
-            .map(String::from)
-    } else if body.is_string() {
-        Some(body.as_str().unwrap().to_string()) // Directly use the string
-    } else {
-        None
-    };
+    // Call the core function with the extracted data
+    let auth_options = handle_start_authentication_core(&body).await?;
 
-    match start_authentication(username).await {
-        Ok(auth_options) => Ok(Json(auth_options)),
-        Err(e) => {
-            tracing::debug!("Error: {:#?}", e);
-            Err((StatusCode::BAD_REQUEST, e.to_string()))
-        }
-    }
+    // Return the authentication options as JSON
+    Ok(Json(auth_options))
 }
+
 
 pub(crate) async fn handle_finish_authentication(
     Json(auth_response): Json<AuthenticatorResponse>,
 ) -> Result<(HeaderMap, String), (StatusCode, String)> {
-    tracing::debug!("Auth response: {:#?}", auth_response);
+    // Call the core function with the extracted data
+    let (_, name, headers) = handle_finish_authentication_core(auth_response).await?;
 
-    let (uid, name) = finish_authentication(auth_response)
-        .await
-        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
-
-    tracing::debug!("User ID: {:#?}", uid);
-
-    let headers = create_session_with_uid(&uid)
-        .await
-        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
-
+    // Return the headers and name
     Ok((headers, name))
 }
 
@@ -209,18 +114,18 @@ pub(crate) async fn serve_conditional_ui_js() -> Response {
         .unwrap()
 }
 
+
+/// Axum handler that extracts AuthUser from the request and delegates to the core function
+///
+/// This function serves as a wrapper that handles the web framework specific parts
+/// (extracting the user from the request) and then calls the core function.
 pub(crate) async fn list_credentials(
     auth_user: Option<AuthUser>,
 ) -> Result<Json<Vec<StoredCredential>>, (StatusCode, String)> {
-    match auth_user {
-        Some(u) => {
-            tracing::debug!("User: {:#?}", u);
-            let credentials =
-                PasskeyStore::get_credentials_by(CredentialSearchField::UserId(u.id.to_owned()))
-                    .await
-                    .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
-            Ok(Json(credentials))
-        }
-        None => Err((StatusCode::BAD_REQUEST, "Not logged in!".to_string())),
-    }
+    // Convert AuthUser to SessionUser if present using deref coercion
+    let session_user = auth_user.as_ref().map(|u| u as &SessionUser);
+
+    // Call the core function with the extracted data
+    let credentials = list_credentials_core(session_user).await?;
+    Ok(Json(credentials))
 }

--- a/libaxum/src/passkey/routes.rs
+++ b/libaxum/src/passkey/routes.rs
@@ -2,7 +2,7 @@ use axum::routing::{Router, get, post};
 
 use super::handlers::{
     conditional_ui, handle_finish_authentication, handle_finish_registration,
-    handle_start_authentication, handle_start_registration, handle_start_registration_get,
+    handle_start_authentication, handle_start_registration_get, handle_start_registration_post,
     list_credentials, serve_conditional_ui_js, serve_passkey_js,
 };
 
@@ -20,7 +20,7 @@ pub fn router_register() -> Router {
     Router::new()
         .route(
             "/start",
-            post(handle_start_registration).get(handle_start_registration_get),
+            post(handle_start_registration_post).get(handle_start_registration_get),
         )
         .route("/finish", post(handle_finish_registration))
 }

--- a/libaxum/static/oauth2.js
+++ b/libaxum/static/oauth2.js
@@ -6,7 +6,7 @@ function initOAuth2Popup() {
         popupWindow = window.open(
             `${AUTH_ROUTE_PREFIX}/google`,
             "PopupWindow",
-            "width=400,height=520,left=1000,top=200,resizable=yes,scrollbars=yes"
+            "width=550,height=640,left=1000,top=200,resizable=yes,scrollbars=yes"
         );
 
         // Listen for messages from the auth popup

--- a/libaxum/templates/popup_close.j2
+++ b/libaxum/templates/popup_close.j2
@@ -12,14 +12,14 @@
             }
             setTimeout(function () {
                 window.close();
-            }, 500);
+            }, 3000);
         }
     </script>
 </head>
 
 <body>
-    <h2>Login Successful</h2>
-    <h2>This window will close automatically within a few seconds...</h2>
+    <h2>{{ message }}</h2>
+    <p>This window will close automatically within a few seconds...</p>
 </body>
 
 </html>

--- a/liboauth2/src/oauth2/mod.rs
+++ b/liboauth2/src/oauth2/mod.rs
@@ -6,6 +6,6 @@ mod utils;
 pub use core::{csrf_checks, get_idinfo_userinfo, prepare_oauth2_auth_request};
 pub(crate) use idtoken::IdInfo;
 pub use utils::{
-    decode_state, delete_session_and_misc_token_from_store, get_uid_from_stored_session_by_state_param,
-    validate_origin,
+    decode_state, delete_session_and_misc_token_from_store,
+    get_uid_from_stored_session_by_state_param, validate_origin,
 };

--- a/libsession/src/types.rs
+++ b/libsession/src/types.rs
@@ -12,6 +12,7 @@ pub struct SessionInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
     pub id: String,
+    pub name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -22,6 +23,7 @@ impl User {
     pub fn into_db_user(self) -> DbUser {
         DbUser {
             id: self.id,
+            name: self.name,
             created_at: self.created_at,
             updated_at: self.updated_at,
         }
@@ -32,6 +34,7 @@ impl From<DbUser> for User {
     fn from(db_user: DbUser) -> Self {
         Self {
             id: db_user.id,
+            name: db_user.name,
             created_at: db_user.created_at,
             updated_at: db_user.updated_at,
         }

--- a/libuserdb/src/types.rs
+++ b/libuserdb/src/types.rs
@@ -6,6 +6,7 @@ use sqlx::FromRow;
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct User {
     pub id: String,
+    pub name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -14,6 +15,7 @@ impl Default for User {
     fn default() -> Self {
         Self {
             id: String::new(),
+            name: String::new(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/libuserdb/src/user/core.rs
+++ b/libuserdb/src/user/core.rs
@@ -52,6 +52,7 @@ async fn create_tables_sqlite(pool: &Pool<Sqlite>) -> Result<(), UserError> {
         r#"
         CREATE TABLE IF NOT EXISTS users (
             id TEXT PRIMARY KEY NOT NULL,
+            name TEXT NOT NULL,
             created_at TIMESTAMP NOT NULL,
             updated_at TIMESTAMP NOT NULL
         )
@@ -80,14 +81,16 @@ async fn upsert_user_sqlite(pool: &Pool<Sqlite>, user: User) -> Result<User, Use
     // Upsert user with a single query
     sqlx::query(
         r#"
-        INSERT INTO users (id, created_at, updated_at)
-        VALUES (?, ?, ?)
+        INSERT INTO users (id, name, created_at, updated_at)
+        VALUES (?, ?, ?, ?)
         ON CONFLICT (id) DO UPDATE SET
+            name = excluded.name,
             created_at = excluded.created_at,
             updated_at = excluded.updated_at
         "#,
     )
     .bind(&user.id)
+    .bind(&user.name)
     .bind(user.created_at)
     .bind(user.updated_at)
     .execute(pool)
@@ -105,6 +108,7 @@ async fn create_tables_postgres(pool: &Pool<Postgres>) -> Result<(), UserError> 
         r#"
         CREATE TABLE IF NOT EXISTS users (
             id TEXT PRIMARY KEY NOT NULL,
+            name TEXT NOT NULL,
             created_at TIMESTAMPTZ NOT NULL,
             updated_at TIMESTAMPTZ NOT NULL
         )
@@ -133,15 +137,17 @@ async fn upsert_user_postgres(pool: &Pool<Postgres>, user: User) -> Result<User,
     // Upsert user with a single query
     sqlx::query(
         r#"
-        INSERT INTO users (id, created_at, updated_at)
-        VALUES ($1, $2, $3)
+        INSERT INTO users (id, name, created_at, updated_at)
+        VALUES ($1, $2, $3, $4)
         ON CONFLICT (id) DO UPDATE SET
+            name = EXCLUDED.name,
             created_at = EXCLUDED.created_at,
             updated_at = EXCLUDED.updated_at
         RETURNING *
         "#,
     )
     .bind(&user.id)
+    .bind(&user.name)
     .bind(user.created_at)
     .bind(user.updated_at)
     .fetch_one(pool)

--- a/monitor_db.sh
+++ b/monitor_db.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Database connection string
+#DB_STRING="psql postgres://passkey:passkey@localhost:5432/passkey"
+DB_STRING="sqlite3 /tmp/sqlite.db"
+
+# SQLite formatting options - using separate commands
+SQLITE_HEADERS=".headers on"
+SQLITE_MODE=".mode column"
+
+# Define queries for each table
+QUERY_USERS="select id,created_at from users;"
+QUERY_PASSKEY_CREDENTIALS="select user_id,credential_id,user_handle,user_name,user_display_name,created_at from passkey_credentials;"
+QUERY_OAUTH2_ACCOUNTS="select user_id,id,provider_user_id,email,created_at from oauth2_accounts;"
+
+# Combine all queries (can be customized by commenting out lines)
+ALL_QUERIES=""
+ALL_QUERIES+="$QUERY_USERS"
+ALL_QUERIES+="$QUERY_PASSKEY_CREDENTIALS"
+ALL_QUERIES+="$QUERY_OAUTH2_ACCOUNTS"
+
+# Run the watch command
+#watch -n 1 "echo '$ALL_QUERIES' | $DB_STRING"
+#watch -n 1 "echo -e '$SQLITE_HEADERS\n$SQLITE_MODE\n$ALL_QUERIES' | $DB_STRING"
+#watch -n 1 "echo '$SQLITE_HEADERS$SQLITE_MODE$ALL_QUERIES' | $DB_STRING"
+
+watch -n 1 'echo "'"$SQLITE_HEADERS
+$SQLITE_MODE
+$ALL_QUERIES"'" | '"$DB_STRING"

--- a/monitor_db.sh
+++ b/monitor_db.sh
@@ -9,7 +9,7 @@ SQLITE_HEADERS=".headers on"
 SQLITE_MODE=".mode column"
 
 # Define queries for each table
-QUERY_USERS="select id,created_at from users;"
+QUERY_USERS="select id,name,created_at from users;"
 QUERY_PASSKEY_CREDENTIALS="select user_id,credential_id,user_handle,user_name,user_display_name,created_at from passkey_credentials;"
 QUERY_OAUTH2_ACCOUNTS="select user_id,id,provider_user_id,email,created_at from oauth2_accounts;"
 


### PR DESCRIPTION
This commit moves the core business logic from the Axum-specific handlers to the libauth crate, improving modularity and separation of concerns:

- Created passkey_flow.rs and oauth2_flow.rs in libauth to house core functions
- Updated handlers in libaxum to use these core functions
- Re-exported necessary types and functions from libauth
- Updated dependencies in libauth/Cargo.toml
- Added libauth to logging configuration

This refactoring makes the core authentication logic independent of the web framework, enabling better testability and potential reuse with other frameworks.