### PR TITLE
feat: Add display_name field to User model

### DIFF
--- a/libauth/src/oauth2_coordinator.rs
+++ b/libauth/src/oauth2_coordinator.rs
@@ -40,7 +40,8 @@ impl OAuth2Coordinator {
         let user = if account.user_id.is_empty() {
             let new_user = User {
                 id: Uuid::new_v4().to_string(),
-                name: account.name.clone(),
+                name: account.email.clone(),
+                display_name: account.name.clone(),
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             };

--- a/libauth/src/oauth2_flow.rs
+++ b/libauth/src/oauth2_flow.rs
@@ -198,12 +198,15 @@ async fn renew_session_header(user_id: String) -> Result<HeaderMap, (StatusCode,
     Ok(headers)
 }
 
+// When creating a new user, we assign email as name and name as display_name.
+// We also assign the user_id to the oauth2_account.
 async fn create_user_and_oauth2account(
     mut oauth2_account: OAuth2Account,
 ) -> Result<String, AuthError> {
     let new_user = DbUser {
         id: uuid::Uuid::new_v4().to_string(),
-        name: oauth2_account.name.clone(),
+        name: oauth2_account.email.clone(),
+        display_name: oauth2_account.name.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
     };

--- a/libauth/src/passkey_coordinator.rs
+++ b/libauth/src/passkey_coordinator.rs
@@ -28,11 +28,12 @@ impl PasskeyCoordinator {
         reg_data: libpasskey::RegisterCredential,
     ) -> Result<String, AuthError> {
         // Get user name from registration data with fallback mechanism
-        let name = reg_data.get_user_name().await;
+        let (name, display_name) = reg_data.get_user_name().await;
 
         let new_user = User {
             id: Uuid::new_v4().to_string(),
             name,
+            display_name,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -66,6 +67,7 @@ impl PasskeyCoordinator {
                 let new_user = User {
                     id: user_id.to_string(),
                     name: "Passkey User".to_string(), // Default name since we don't have reg_data here
+                    display_name: "Passkey User".to_string(), // Default display name since we don't have reg_data here
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
                 };

--- a/libauth/src/passkey_flow.rs
+++ b/libauth/src/passkey_flow.rs
@@ -100,13 +100,14 @@ pub async fn handle_finish_registration_core(
         }
         None => {
             // Get user name from registration data with fallback mechanism
-            let name = reg_data.get_user_name().await;
+            let (name, display_name) = reg_data.get_user_name().await;
             tracing::debug!("User name: {}, registration data: {:#?}", name, reg_data);
 
             // Create a new user for unauthenticated registration
             let new_user = User {
                 id: Uuid::new_v4().to_string(),
                 name,
+                display_name,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             };

--- a/libaxum/templates/user_summary.j2
+++ b/libaxum/templates/user_summary.j2
@@ -173,6 +173,7 @@
         <div class="item">
             <div class="item-detail"><strong>User ID:</strong> {{ user.id }}</div>
             <div class="item-detail"><strong>Name:</strong> {{ user.name }}</div>
+            <div class="item-detail"><strong>Display Name:</strong> {{ user.display_name }}</div>
             <div class="item-detail"><strong>Created:</strong> {{ user.created_at }}</div>
             <div class="item-detail"><strong>Updated:</strong> {{ user.updated_at }}</div>
         </div>

--- a/libpasskey/src/passkey/types.rs
+++ b/libpasskey/src/passkey/types.rs
@@ -87,19 +87,19 @@ pub struct RegisterCredential {
 impl RegisterCredential {
     /// Attempts to retrieve the stored user entity for this registration
     /// If the stored options are no longer available, falls back to a default value
-    pub async fn get_user_name(&self) -> String {
+    pub async fn get_user_name(&self) -> (String, String) {
         // Try to get the stored options if user_handle exists
         if let Some(handle) = &self.user_handle {
             match super::challenge::get_and_validate_options("regi_challenge", handle).await {
-                Ok(stored_options) => stored_options.user.name,
+                Ok(stored_options) => (stored_options.user.name, stored_options.user.display_name),
                 Err(e) => {
                     tracing::warn!("Failed to get stored user: {}", e);
-                    "Passkey User".to_string()
+                    ("Passkey User".to_string(), "Passkey User".to_string())
                 }
             }
         } else {
             // Fall back to default if user_handle is None
-            "Passkey User".to_string()
+            ("Passkey User".to_string(), "Passkey User".to_string())
         }
     }
 }

--- a/libsession/src/types.rs
+++ b/libsession/src/types.rs
@@ -13,6 +13,7 @@ pub struct SessionInfo {
 pub struct User {
     pub id: String,
     pub name: String,
+    pub display_name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -24,6 +25,7 @@ impl User {
         DbUser {
             id: self.id,
             name: self.name,
+            display_name: self.display_name,
             created_at: self.created_at,
             updated_at: self.updated_at,
         }
@@ -35,6 +37,7 @@ impl From<DbUser> for User {
         Self {
             id: db_user.id,
             name: db_user.name,
+            display_name: db_user.display_name,
             created_at: db_user.created_at,
             updated_at: db_user.updated_at,
         }

--- a/libuserdb/src/types.rs
+++ b/libuserdb/src/types.rs
@@ -7,6 +7,7 @@ use sqlx::FromRow;
 pub struct User {
     pub id: String,
     pub name: String,
+    pub display_name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -16,6 +17,7 @@ impl Default for User {
         Self {
             id: String::new(),
             name: String::new(),
+            display_name: String::new(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/libuserdb/src/user/core.rs
+++ b/libuserdb/src/user/core.rs
@@ -53,6 +53,7 @@ async fn create_tables_sqlite(pool: &Pool<Sqlite>) -> Result<(), UserError> {
         CREATE TABLE IF NOT EXISTS users (
             id TEXT PRIMARY KEY NOT NULL,
             name TEXT NOT NULL,
+            display_name TEXT NOT NULL,
             created_at TIMESTAMP NOT NULL,
             updated_at TIMESTAMP NOT NULL
         )
@@ -81,16 +82,18 @@ async fn upsert_user_sqlite(pool: &Pool<Sqlite>, user: User) -> Result<User, Use
     // Upsert user with a single query
     sqlx::query(
         r#"
-        INSERT INTO users (id, name, created_at, updated_at)
-        VALUES (?, ?, ?, ?)
+        INSERT INTO users (id, name, display_name, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
         ON CONFLICT (id) DO UPDATE SET
             name = excluded.name,
+            display_name = excluded.display_name,
             created_at = excluded.created_at,
             updated_at = excluded.updated_at
         "#,
     )
     .bind(&user.id)
     .bind(&user.name)
+    .bind(&user.display_name)
     .bind(user.created_at)
     .bind(user.updated_at)
     .execute(pool)
@@ -109,6 +112,7 @@ async fn create_tables_postgres(pool: &Pool<Postgres>) -> Result<(), UserError> 
         CREATE TABLE IF NOT EXISTS users (
             id TEXT PRIMARY KEY NOT NULL,
             name TEXT NOT NULL,
+            display_name TEXT NOT NULL,
             created_at TIMESTAMPTZ NOT NULL,
             updated_at TIMESTAMPTZ NOT NULL
         )
@@ -137,10 +141,11 @@ async fn upsert_user_postgres(pool: &Pool<Postgres>, user: User) -> Result<User,
     // Upsert user with a single query
     sqlx::query(
         r#"
-        INSERT INTO users (id, name, created_at, updated_at)
-        VALUES ($1, $2, $3, $4)
+        INSERT INTO users (id, name, display_name, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5)
         ON CONFLICT (id) DO UPDATE SET
             name = EXCLUDED.name,
+            display_name = EXCLUDED.display_name,
             created_at = EXCLUDED.created_at,
             updated_at = EXCLUDED.updated_at
         RETURNING *
@@ -148,6 +153,7 @@ async fn upsert_user_postgres(pool: &Pool<Postgres>, user: User) -> Result<User,
     )
     .bind(&user.id)
     .bind(&user.name)
+    .bind(&user.display_name)
     .bind(user.created_at)
     .bind(user.updated_at)
     .fetch_one(pool)


### PR DESCRIPTION
This commit adds a display_name field to the User model across the entire codebase:
- Update User struct in libuserdb and libsession
- Modify database schemas for both SQLite and PostgreSQL
- Update OAuth2 user creation to use email as name and name as display_name
- Modify passkey registration to handle both name and display_name
- Update user summary template to display the new field

This change improves user identification by separating the technical identifier (name/email) from the human-readable display name shown in the UI.