### PR TITLE
feat: Add pre-filling of passkey registration form with user data

### DIFF
--- a/libaxum/static/passkey.js
+++ b/libaxum/static/passkey.js
@@ -140,6 +140,30 @@ function createRegistrationModal() {
 function showRegistrationModal() {
     const modal = createRegistrationModal();
     modal.style.display = 'block';
+
+    // Try to get current user info to pre-fill the form
+    fetch('/summary/user-info', {
+        method: 'GET',
+        credentials: 'same-origin'
+    })
+    .then(response => {
+        if (response.ok) {
+            return response.json();
+        }
+        // If not logged in or error, just leave the form empty
+        return null;
+    })
+    .then(userData => {
+        if (userData) {
+            // Pre-fill the form with user data
+            document.getElementById('reg-username').value = userData.name || '';
+            document.getElementById('reg-displayname').value = userData.display_name || '';
+        }
+    })
+    .catch(error => {
+        console.error('Error fetching user data:', error);
+        // Continue without pre-filling
+    });
 }
 
 function closeRegistrationModal() {


### PR DESCRIPTION
This commit adds functionality to pre-fill the passkey registration form with the current user's information when they are logged in:

- Add a new `/summary/user-info` API endpoint that returns basic user information
- Update the passkey registration modal JavaScript to fetch and use this data
- Pre-fill username and display name fields with the user's current values

This improves the user experience by reducing the need to re-enter information that's already available in the system, while maintaining the clean architecture and minimizing code changes.