### PR TITLE
refactor: rename User struct fields and improve passkey registration UX

### DIFF
--- a/demo-integration/src/handlers.rs
+++ b/demo-integration/src/handlers.rs
@@ -33,7 +33,7 @@ struct ProtectedTemplate<'a> {
 pub(crate) async fn index(user: Option<User>) -> Result<Html<String>, (StatusCode, String)> {
     match user {
         Some(u) => {
-            let message = format!("Hey {}!", u.name);
+            let message = format!("Hey {}!", u.account);
             let template = IndexTemplateUser {
                 // user: u.clone(),
                 message: &message,

--- a/libauth/src/oauth2_coordinator.rs
+++ b/libauth/src/oauth2_coordinator.rs
@@ -40,8 +40,8 @@ impl OAuth2Coordinator {
         let user = if account.user_id.is_empty() {
             let new_user = User {
                 id: Uuid::new_v4().to_string(),
-                name: account.email.clone(),
-                display_name: account.name.clone(),
+                account: account.email.clone(),
+                label: account.name.clone(),
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             };

--- a/libauth/src/oauth2_flow.rs
+++ b/libauth/src/oauth2_flow.rs
@@ -110,7 +110,7 @@ pub async fn process_oauth2_authorization(
         .into_response_error()?;
 
     let (state_user_id, state_user_name) = match &state_user {
-        Some(user) => (Some(user.id.clone()), Some(user.name.clone())),
+        Some(user) => (Some(user.id.clone()), Some(user.account.clone())),
         None => (None, None),
     };
 
@@ -205,8 +205,8 @@ async fn create_user_and_oauth2account(
 ) -> Result<String, AuthError> {
     let new_user = DbUser {
         id: uuid::Uuid::new_v4().to_string(),
-        name: oauth2_account.email.clone(),
-        display_name: oauth2_account.name.clone(),
+        account: oauth2_account.email.clone(),
+        label: oauth2_account.name.clone(),
         created_at: Utc::now(),
         updated_at: Utc::now(),
     };

--- a/libauth/src/passkey_coordinator.rs
+++ b/libauth/src/passkey_coordinator.rs
@@ -32,8 +32,8 @@ impl PasskeyCoordinator {
 
         let new_user = User {
             id: Uuid::new_v4().to_string(),
-            name,
-            display_name,
+            account: name,
+            label: display_name,
             created_at: Utc::now(),
             updated_at: Utc::now(),
         };
@@ -66,8 +66,8 @@ impl PasskeyCoordinator {
                 // User doesn't exist, so we should create one
                 let new_user = User {
                     id: user_id.to_string(),
-                    name: "Passkey User".to_string(), // Default name since we don't have reg_data here
-                    display_name: "Passkey User".to_string(), // Default display name since we don't have reg_data here
+                    account: "Passkey User".to_string(), // Default account since we don't have reg_data here
+                    label: "Passkey User".to_string(), // Default label since we don't have reg_data here
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
                 };

--- a/libauth/src/passkey_flow.rs
+++ b/libauth/src/passkey_flow.rs
@@ -106,8 +106,8 @@ pub async fn handle_finish_registration_core(
             // Create a new user for unauthenticated registration
             let new_user = User {
                 id: Uuid::new_v4().to_string(),
-                name,
-                display_name,
+                account: name,
+                label: display_name,
                 created_at: Utc::now(),
                 updated_at: Utc::now(),
             };

--- a/libaxum/src/summary/handlers.rs
+++ b/libaxum/src/summary/handlers.rs
@@ -30,11 +30,22 @@ pub fn router() -> Router<()> {
 pub async fn user_info(auth_user: Option<AuthUser>) -> Result<Json<Value>, (StatusCode, String)> {
     match auth_user {
         Some(user) => {
+            // Get passkey credentials count for the user
+            let stored_credentials = list_credentials_core(Some(&user))
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Failed to fetch credentials: {:?}", e),
+                    )
+                })?;
+
             // Return user information as JSON
             let user_data = json!({
                 "id": user.id,
-                "name": user.name,
-                "display_name": user.display_name
+                "account": user.account,
+                "label": user.label,
+                "passkey_count": stored_credentials.len()
             });
 
             Ok(Json(user_data))

--- a/libaxum/static/passkey.js
+++ b/libaxum/static/passkey.js
@@ -156,8 +156,8 @@ function showRegistrationModal() {
     .then(userData => {
         if (userData) {
             // Pre-fill the form with user data
-            document.getElementById('reg-username').value = userData.name || '';
-            document.getElementById('reg-displayname').value = userData.display_name || '';
+            document.getElementById('reg-username').value = userData.account ? `${userData.account}#${userData.passkey_count + 1}` : 'username';
+            document.getElementById('reg-displayname').value = userData.label ? `${userData.label}#${userData.passkey_count + 1}` : 'displayname';
         }
     })
     .catch(error => {

--- a/libaxum/templates/user_summary.j2
+++ b/libaxum/templates/user_summary.j2
@@ -172,8 +172,8 @@
         <h2 class="section-title">User Information</h2>
         <div class="item">
             <div class="item-detail"><strong>User ID:</strong> {{ user.id }}</div>
-            <div class="item-detail"><strong>Name:</strong> {{ user.name }}</div>
-            <div class="item-detail"><strong>Display Name:</strong> {{ user.display_name }}</div>
+            <div class="item-detail"><strong>Account:</strong> {{ user.account }}</div>
+            <div class="item-detail"><strong>Label:</strong> {{ user.label }}</div>
             <div class="item-detail"><strong>Created:</strong> {{ user.created_at }}</div>
             <div class="item-detail"><strong>Updated:</strong> {{ user.updated_at }}</div>
         </div>

--- a/libsession/src/types.rs
+++ b/libsession/src/types.rs
@@ -12,8 +12,8 @@ pub struct SessionInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
     pub id: String,
-    pub name: String,
-    pub display_name: String,
+    pub account: String,
+    pub label: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -24,8 +24,8 @@ impl User {
     pub fn into_db_user(self) -> DbUser {
         DbUser {
             id: self.id,
-            name: self.name,
-            display_name: self.display_name,
+            account: self.account,
+            label: self.label,
             created_at: self.created_at,
             updated_at: self.updated_at,
         }
@@ -36,8 +36,8 @@ impl From<DbUser> for User {
     fn from(db_user: DbUser) -> Self {
         Self {
             id: db_user.id,
-            name: db_user.name,
-            display_name: db_user.display_name,
+            account: db_user.account,
+            label: db_user.label,
             created_at: db_user.created_at,
             updated_at: db_user.updated_at,
         }

--- a/libuserdb/src/types.rs
+++ b/libuserdb/src/types.rs
@@ -6,8 +6,8 @@ use sqlx::FromRow;
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct User {
     pub id: String,
-    pub name: String,
-    pub display_name: String,
+    pub account: String,
+    pub label: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -16,8 +16,8 @@ impl Default for User {
     fn default() -> Self {
         Self {
             id: String::new(),
-            name: String::new(),
-            display_name: String::new(),
+            account: String::new(),
+            label: String::new(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }

--- a/libuserdb/src/user/core.rs
+++ b/libuserdb/src/user/core.rs
@@ -52,8 +52,8 @@ async fn create_tables_sqlite(pool: &Pool<Sqlite>) -> Result<(), UserError> {
         r#"
         CREATE TABLE IF NOT EXISTS users (
             id TEXT PRIMARY KEY NOT NULL,
-            name TEXT NOT NULL,
-            display_name TEXT NOT NULL,
+            account TEXT NOT NULL,
+            label TEXT NOT NULL,
             created_at TIMESTAMP NOT NULL,
             updated_at TIMESTAMP NOT NULL
         )
@@ -82,18 +82,18 @@ async fn upsert_user_sqlite(pool: &Pool<Sqlite>, user: User) -> Result<User, Use
     // Upsert user with a single query
     sqlx::query(
         r#"
-        INSERT INTO users (id, name, display_name, created_at, updated_at)
+        INSERT INTO users (id, account, label, created_at, updated_at)
         VALUES (?, ?, ?, ?, ?)
         ON CONFLICT (id) DO UPDATE SET
-            name = excluded.name,
-            display_name = excluded.display_name,
+            account = excluded.account,
+            label = excluded.label,
             created_at = excluded.created_at,
             updated_at = excluded.updated_at
         "#,
     )
     .bind(&user.id)
-    .bind(&user.name)
-    .bind(&user.display_name)
+    .bind(&user.account)
+    .bind(&user.label)
     .bind(user.created_at)
     .bind(user.updated_at)
     .execute(pool)
@@ -111,8 +111,8 @@ async fn create_tables_postgres(pool: &Pool<Postgres>) -> Result<(), UserError> 
         r#"
         CREATE TABLE IF NOT EXISTS users (
             id TEXT PRIMARY KEY NOT NULL,
-            name TEXT NOT NULL,
-            display_name TEXT NOT NULL,
+            account TEXT NOT NULL,
+            label TEXT NOT NULL,
             created_at TIMESTAMPTZ NOT NULL,
             updated_at TIMESTAMPTZ NOT NULL
         )
@@ -141,19 +141,19 @@ async fn upsert_user_postgres(pool: &Pool<Postgres>, user: User) -> Result<User,
     // Upsert user with a single query
     sqlx::query(
         r#"
-        INSERT INTO users (id, name, display_name, created_at, updated_at)
+        INSERT INTO users (id, account, label, created_at, updated_at)
         VALUES ($1, $2, $3, $4, $5)
         ON CONFLICT (id) DO UPDATE SET
-            name = EXCLUDED.name,
-            display_name = EXCLUDED.display_name,
+            account = EXCLUDED.account,
+            label = EXCLUDED.label,
             created_at = EXCLUDED.created_at,
             updated_at = EXCLUDED.updated_at
         RETURNING *
         "#,
     )
     .bind(&user.id)
-    .bind(&user.name)
-    .bind(&user.display_name)
+    .bind(&user.account)
+    .bind(&user.label)
     .bind(user.created_at)
     .bind(user.updated_at)
     .fetch_one(pool)


### PR DESCRIPTION
- Rename User.name to User.account and User.display_name to User.label to decouple field names from specific identity concepts
- Update all references across the codebase including:
  - Database schemas and SQL queries
  - User struct instantiations and field accesses
  - JSON responses and frontend interactions
- Maintain WebAuthn protocol compatibility by keeping name/display_name in PublicKeyCredentialUserEntity
- Enhance user info endpoint to include passkey credential count
- Improve passkey registration UX by:
  - Adding sequential numbering to default username/displayname suggestions
  - Using format `${account}#${passkey_count + 1}` for better credential identification
  - Providing meaningful fallback values ('username'/'displayname') when no existing data

This change improves the semantic clarity of the User model while maintaining compatibility with external protocols and standards.