### PR TITLE
refactor: Simplify passkey registration flow

### DIFF
--- a/demo-passkey/templates/index.j2
+++ b/demo-passkey/templates/index.j2
@@ -36,15 +36,7 @@
         </div>
         <div id="auth-register" style="display: block">
             <!-- Will show auth buttons based on state -->
-            {# <button onclick="startRegistration(true)" class="auth-button"> #}
             <button onclick="showRegistrationModal()" class="auth-button">
-                    Register New Passkey
-            </button>
-        </div>
-        <div id="auth-register" style="display: block">
-            <h1>RegisterPasskeyfromSession</h1>
-            <!-- Will show auth buttons based on state -->
-            <button onclick="startRegistration(false)" class="auth-button">
                 Register New Passkey
             </button>
         </div>

--- a/libauth/src/lib.rs
+++ b/libauth/src/lib.rs
@@ -19,8 +19,7 @@ pub use oauth2_flow::{
 pub use passkey_coordinator::PasskeyCoordinator;
 pub use passkey_flow::{
     handle_finish_authentication_core, handle_finish_registration_core,
-    handle_start_authentication_core, handle_start_registration_get_core,
-    handle_start_registration_post_core, list_credentials_core,
+    handle_start_authentication_core, handle_start_registration_post_core, list_credentials_core,
 };
 
 pub use liboauth2::{

--- a/libaxum/src/passkey/handlers.rs
+++ b/libaxum/src/passkey/handlers.rs
@@ -9,29 +9,13 @@ use serde_json::Value;
 use libauth::{
     AuthenticationOptions, AuthenticatorResponse, RegisterCredential, RegistrationOptions,
     handle_finish_authentication_core, handle_finish_registration_core,
-    handle_start_authentication_core, handle_start_registration_get_core,
-    handle_start_registration_post_core, list_credentials_core,
+    handle_start_authentication_core, handle_start_registration_post_core, list_credentials_core,
 };
 
 use libpasskey::{PASSKEY_ROUTE_PREFIX, StoredCredential};
 use libsession::User as SessionUser;
 
 use crate::session::AuthUser;
-
-/// Axum handler that extracts AuthUser from the request and delegates to the core function
-pub(crate) async fn handle_start_registration_get(
-    user: Option<AuthUser>,
-) -> Result<Json<RegistrationOptions>, (StatusCode, String)> {
-    // Convert AuthUser to SessionUser if present using deref coercion
-    let session_user = user.as_ref().map(|u| u as &SessionUser);
-
-    // Call the core function with the extracted data
-    let options = handle_start_registration_get_core(session_user)
-        .await
-        .expect("Failed to start registration");
-
-    Ok(Json(options))
-}
 
 pub(crate) async fn handle_start_registration_post(
     auth_user: Option<AuthUser>,

--- a/libaxum/src/passkey/routes.rs
+++ b/libaxum/src/passkey/routes.rs
@@ -2,8 +2,8 @@ use axum::routing::{Router, get, post};
 
 use super::handlers::{
     conditional_ui, handle_finish_authentication, handle_finish_registration,
-    handle_start_authentication, handle_start_registration_get, handle_start_registration_post,
-    list_passkey_credentials, serve_conditional_ui_js, serve_passkey_js,
+    handle_start_authentication, handle_start_registration_post, list_passkey_credentials,
+    serve_conditional_ui_js, serve_passkey_js,
 };
 
 pub fn router() -> Router {
@@ -18,10 +18,7 @@ pub fn router() -> Router {
 
 pub fn router_register() -> Router {
     Router::new()
-        .route(
-            "/start",
-            post(handle_start_registration_post).get(handle_start_registration_get),
-        )
+        .route("/start", post(handle_start_registration_post))
         .route("/finish", post(handle_finish_registration))
 }
 

--- a/libaxum/static/passkey.js
+++ b/libaxum/static/passkey.js
@@ -187,30 +187,19 @@ async function submitRegistration() {
     }
 
     closeRegistrationModal();
-    await startRegistration(true, username, displayname);
+    await startRegistration(username, displayname);
 }
 
-async function startRegistration(withUsername = true, username = null, displayname = null) {
+async function startRegistration(username = null, displayname = null) {
     try {
         let startResponse;
-        // let username;
-
-        if (withUsername) {
-            // username = prompt("Please enter your username:");
-            // if (!username) return;
-
-            startResponse = await fetch(PASSKEY_ROUTE_PREFIX + '/register/start', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ username, displayname })
-            });
-        } else {
-            startResponse = await fetch(PASSKEY_ROUTE_PREFIX + '/register/start', {
-                method: 'GET',
-            });
-        }
+        startResponse = await fetch(PASSKEY_ROUTE_PREFIX + '/register/start', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ username, displayname })
+        });
 
         if (!startResponse.ok) {
             const errorText = await startResponse.text();


### PR DESCRIPTION
Streamline the passkey registration process by removing the OAuth2-specific registration path and unifying the registration flow.

Changes:
- Remove GET endpoint for registration start
- Remove OAuth2-specific registration handler
- Simplify registration modal UI
- Remove duplicate registration button
- Clean up passkey.js registration logic
- Remove unnecessary OAuth2 dependency from passkey flow

The changes maintain the core functionality while reducing code complexity and improving maintainability. Registration now consistently uses a single POST endpoint with user-provided fields.