### PR TITLE
feat: Add WebAuthn well-known endpoint for related origins

### DIFF
--- a/demo-integration/src/main.rs
+++ b/demo-integration/src/main.rs
@@ -2,7 +2,7 @@ use axum::{Router, routing::get};
 use dotenv::dotenv;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use libaxum::{oauth2_router, passkey_router, summary_router};
+use libaxum::{oauth2_router, passkey_router, related_origin_router, summary_router};
 use liboauth2::OAUTH2_ROUTE_PREFIX;
 use libpasskey::PASSKEY_ROUTE_PREFIX;
 
@@ -77,7 +77,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/protected", get(protected))
         .nest("/summary", summary_router())
         .nest(OAUTH2_ROUTE_PREFIX.as_str(), oauth2_router())
-        .nest(PASSKEY_ROUTE_PREFIX.as_str(), passkey_router());
+        .nest(PASSKEY_ROUTE_PREFIX.as_str(), passkey_router())
+        .merge(related_origin_router()); // Mount the WebAuthn well-known endpoint at root level
 
     let ports = Ports {
         http: 3001,

--- a/libaxum/src/lib.rs
+++ b/libaxum/src/lib.rs
@@ -4,6 +4,7 @@ mod session;
 mod summary;
 
 pub use oauth2::router as oauth2_router;
+pub use passkey::related_origin_router;
 pub use passkey::router as passkey_router;
 pub use session::AuthUser;
 pub use summary::router as summary_router;

--- a/libaxum/src/passkey/mod.rs
+++ b/libaxum/src/passkey/mod.rs
@@ -1,4 +1,4 @@
 mod handlers;
 mod routes;
 
-pub use routes::router;
+pub use routes::{related_origin_router, router};

--- a/libaxum/src/passkey/routes.rs
+++ b/libaxum/src/passkey/routes.rs
@@ -3,7 +3,7 @@ use axum::routing::{Router, get, post};
 use super::handlers::{
     conditional_ui, handle_finish_authentication, handle_finish_registration,
     handle_start_authentication, handle_start_registration_post, list_passkey_credentials,
-    serve_conditional_ui_js, serve_passkey_js,
+    serve_conditional_ui_js, serve_passkey_js, serve_related_origin,
 };
 
 pub fn router() -> Router {
@@ -26,4 +26,10 @@ pub fn router_auth() -> Router {
     Router::new()
         .route("/start", post(handle_start_authentication))
         .route("/finish", post(handle_finish_authentication))
+}
+
+/// Creates a router for the WebAuthn well-known endpoint
+/// This should be mounted at the root level of the application
+pub fn related_origin_router() -> Router {
+    Router::new().route("/.well-known/webauthn", get(serve_related_origin))
 }

--- a/libpasskey/src/lib.rs
+++ b/libpasskey/src/lib.rs
@@ -4,6 +4,7 @@ mod errors;
 mod passkey;
 mod storage;
 mod types;
+
 pub use common::{gen_random_string, init};
 pub use config::PASSKEY_ROUTE_PREFIX; // Required for route configuration
 pub use errors::PasskeyError;
@@ -11,7 +12,7 @@ pub use errors::PasskeyError;
 pub use passkey::{
     AuthenticationOptions, AuthenticatorResponse, RegisterCredential, RegistrationOptions,
     finish_authentication, finish_registration, finish_registration_with_auth_user,
-    start_authentication, start_registration,
+    get_related_origin_json, start_authentication, start_registration,
 };
 
 pub use storage::PasskeyStore;

--- a/libpasskey/src/passkey/mod.rs
+++ b/libpasskey/src/passkey/mod.rs
@@ -2,6 +2,7 @@ mod attestation;
 mod auth;
 mod challenge;
 mod register;
+mod related_origin;
 mod types;
 
 pub use types::{
@@ -10,3 +11,4 @@ pub use types::{
 
 pub use auth::{finish_authentication, start_authentication};
 pub use register::{finish_registration, finish_registration_with_auth_user, start_registration};
+pub use related_origin::get_related_origin_json;

--- a/libpasskey/src/passkey/related_origin.rs
+++ b/libpasskey/src/passkey/related_origin.rs
@@ -1,0 +1,50 @@
+use serde::Serialize;
+use std::env;
+use std::sync::LazyLock;
+
+use crate::config::{ORIGIN, PASSKEY_RP_ID};
+use crate::errors::PasskeyError;
+
+#[derive(Serialize)]
+pub struct WebAuthnConfig {
+    /// The WebAuthn relying party ID
+    #[serde(rename = "rp_id")]
+    rp_id: String,
+
+    /// List of origins that are allowed to use this WebAuthn configuration
+    #[serde(rename = "origins")]
+    origins: Vec<String>,
+}
+
+// Static configuration for additional origins
+static ADDITIONAL_ORIGINS: LazyLock<Vec<String>> = LazyLock::new(|| {
+    env::var("WEBAUTHN_ADDITIONAL_ORIGINS")
+        .map(|origins| {
+            origins
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+});
+
+/// Generate the WebAuthn configuration JSON
+///
+/// This function returns the WebAuthn configuration as a JSON string.
+/// It includes the RP ID and all allowed origins (main origin + additional origins).
+pub fn get_related_origin_json() -> Result<String, PasskeyError> {
+    // Get the RP ID and origin
+    let rp_id = PASSKEY_RP_ID.clone();
+    let origin = ORIGIN.clone();
+
+    // Collect all origins (main origin + additional origins)
+    let mut origins = vec![origin];
+    origins.extend(ADDITIONAL_ORIGINS.iter().cloned());
+
+    // Create the WebAuthn configuration
+    let config = WebAuthnConfig { rp_id, origins };
+
+    // Serialize to JSON
+    serde_json::to_string_pretty(&config).map_err(|e| PasskeyError::Serde(e.to_string()))
+}


### PR DESCRIPTION
Implement the WebAuthn well-known endpoint (/.well-known/webauthn) to support cross-origin credential management. This endpoint serves a JSON configuration containing the relying party ID and allowed origins.

Key changes:
- Add related_origin.rs module with WebAuthnConfig structure
- Support additional origins via WEBAUTHN_ADDITIONAL_ORIGINS environment variable
- Create router for the well-known endpoint that merges at the application root
- Export necessary functions with minimal visibility

This implementation follows the WebAuthn specification for related origins and enhances cross-origin credential management capabilities.