### PR TITLE
feat: Implement comprehensive account management functionality

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,13 +4,22 @@
 
 - Middleware based page protection i.e. create a likes of is_authorized middleware.
 - Consolidate liboauth2, libpasskey, libsession and libstorage into libauth.
+- Standardize binary data encoding throughout the backend codebase:
+  - Use Base64 URL_SAFE_NO_PAD consistently for all credential IDs and public keys
+  - Update database schema and existing records if necessary
+  - We'll do this after the tests are implemented
+- Passkey sync between RP and Authenticator using Signal API.
+
+## Done
+
+- ~~Enable modification of User.account and User.label for logged in user.~~
+- ~~Enable deletion of logged in user then logout.~~
+
+- ~~Enable deletion of Passkey credential for logged in user.~~
+- ~~Enable unlinking of OAuth2 account for logged in user.~~
 - ~~Examine if we should use OAuth2Coordinator and PasskeyCoordinator.~~
 - ~~Autofill user.name as default values for Passkey register dialog's name and display name.~~
 - ~~Related Origin Requests
 (https://passkeys.dev/docs/advanced/related-origins/)~~
 - ~~Use parseCreationOptionsFromJSON and parseAuthenticationOptionsFromJSON to simplify passkey.js implementation.~~ Won't do as this requires webauthn-json dependency.
 - ~~Deal with halfway registration and authentication in passkey.js.~~
-- Enable modification of User.account and User.label for logged in user.
-- Enable deletion of Passkey credential for logged in user.
-  - Passkey sync between RP and Authenticator using Signal API.
-- Enable unlinking of OAuth2 account for logged in user.

--- a/demo-integration/src/main.rs
+++ b/demo-integration/src/main.rs
@@ -2,7 +2,7 @@ use axum::{Router, routing::get};
 use dotenv::dotenv;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use libaxum::{oauth2_router, passkey_router, related_origin_router, summary_router};
+use libaxum::{oauth2_router, passkey_router, passkey_well_known_router, summary_router};
 use liboauth2::OAUTH2_ROUTE_PREFIX;
 use libpasskey::PASSKEY_ROUTE_PREFIX;
 
@@ -78,7 +78,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .nest("/summary", summary_router())
         .nest(OAUTH2_ROUTE_PREFIX.as_str(), oauth2_router())
         .nest(PASSKEY_ROUTE_PREFIX.as_str(), passkey_router())
-        .merge(related_origin_router()); // Mount the WebAuthn well-known endpoint at root level
+        .nest("/.well-known", passkey_well_known_router()); // Mount the WebAuthn well-known endpoint at root level
 
     let ports = Ports {
         http: 3001,

--- a/libauth/Cargo.toml
+++ b/libauth/Cargo.toml
@@ -13,8 +13,10 @@ libuserdb = { path = "../libuserdb" }
 libstorage = { path = "../libstorage" }
 libsession = { path = "../libsession" }
 
+base64 = "0.21"
 chrono.workspace = true
 headers.workspace = true
+hex = "0.4.3"
 http.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/libauth/src/lib.rs
+++ b/libauth/src/lib.rs
@@ -6,25 +6,28 @@
 mod errors;
 mod oauth2_flow;
 mod passkey_flow;
+mod user_flow;
 
 // Re-export the main coordination components
 pub use errors::AuthError;
 pub use oauth2_flow::{
-    get_authorized_core, get_oauth2_accounts, list_accounts_core, post_authorized_core,
-    process_oauth2_authorization,
+    delete_oauth2_account_core, get_authorized_core, get_oauth2_accounts, list_accounts_core,
+    post_authorized_core, process_oauth2_authorization,
 };
 pub use passkey_flow::{
-    handle_finish_authentication_core, handle_finish_registration_core,
-    handle_start_authentication_core, handle_start_registration_post_core, list_credentials_core,
+    delete_passkey_credential_core, handle_finish_authentication_core,
+    handle_finish_registration_core, handle_start_authentication_core,
+    handle_start_registration_post_core, list_credentials_core,
 };
+pub use user_flow::{delete_user_account, update_user_account};
 
 pub use liboauth2::{
     AuthResponse, OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME, OAUTH2_ROUTE_PREFIX, OAuth2Account,
-    csrf_checks, prepare_oauth2_auth_request, validate_origin,
+    OAuth2Store, csrf_checks, prepare_oauth2_auth_request, validate_origin,
 };
 
 pub use libpasskey::{
-    AuthenticationOptions, AuthenticatorResponse, PublicKeyCredentialUserEntity,
+    AuthenticationOptions, AuthenticatorResponse, PasskeyStore, PublicKeyCredentialUserEntity,
     RegisterCredential, RegistrationOptions, finish_authentication, finish_registration,
     gen_random_string, start_authentication, start_registration,
     verify_session_then_finish_registration,

--- a/libauth/src/passkey_flow.rs
+++ b/libauth/src/passkey_flow.rs
@@ -201,3 +201,81 @@ pub async fn list_credentials_core(
         None => Err((StatusCode::BAD_REQUEST, "Not logged in!".to_string())),
     }
 }
+
+/// Delete a passkey credential for a user
+///
+/// This function checks that the credential belongs to the authenticated user
+/// before deleting it to prevent unauthorized deletions.
+pub async fn delete_passkey_credential_core(
+    user: Option<&SessionUser>,
+    credential_id: &str,
+) -> Result<(), (StatusCode, String)> {
+    // Ensure user is authenticated
+    let user = match user {
+        Some(user) => user,
+        None => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                "User not authenticated".to_string(),
+            ));
+        }
+    };
+
+    // The credential_id from the UI is in hex format, but in the database it's stored directly as a string
+    // So we need to use it directly without conversion
+    tracing::debug!("Attempting to delete credential with ID: {}", credential_id);
+    
+    // Get all credentials for this user to find the matching one
+    let user_credentials = PasskeyStore::get_credentials_by(CredentialSearchField::UserId(
+        user.id.to_owned(),
+    ))
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    
+    tracing::debug!("Found {} credentials for user", user_credentials.len());
+    
+    // Find the credential with the matching ID
+    let credential = user_credentials
+        .into_iter()
+        .find(|c| {
+            // The credential_id in the UI is displayed in hex format, so we need to convert
+            // the binary credential_id from the database to hex for comparison
+            let hex_id = hex::encode(&c.credential_id);
+            tracing::debug!("Comparing credential ID: {} with {}", hex_id, credential_id);
+            hex_id == credential_id
+        })
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            "Passkey credential not found".to_string(),
+        ))?;
+
+    // Verify the credential belongs to the authenticated user
+    if credential.user_id != user.id {
+        return Err((
+            StatusCode::FORBIDDEN,
+            "Not authorized to delete this credential".to_string(),
+        ));
+    }
+
+    // The credential ID in the database is stored directly as a string
+    // We need to use the exact credential ID as it appears in the database
+    
+    // Get the raw credential ID string from the database record
+    let raw_credential_id = std::str::from_utf8(&credential.credential_id)
+        .map_err(|_| (StatusCode::INTERNAL_SERVER_ERROR, "Invalid credential ID encoding".to_string()))?
+        .to_string();
+    
+    tracing::debug!("Deleting credential with raw database ID: {}", raw_credential_id);
+    
+    // Delete the credential using the raw credential ID format from the database
+    PasskeyStore::delete_credential_by(CredentialSearchField::CredentialId(raw_credential_id))
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete credential: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+        })?;
+        
+    tracing::debug!("Successfully deleted credential");
+
+    Ok(())
+}

--- a/libauth/src/user_flow.rs
+++ b/libauth/src/user_flow.rs
@@ -44,10 +44,12 @@ pub async fn update_user_account(
 /// Delete a user account and all associated OAuth2 accounts and Passkey credentials
 pub async fn delete_user_account(user_id: &str) -> Result<(), UserFlowError> {
     // Check if the user exists
-    let _user = UserStore::get_user(user_id)
+    let user = UserStore::get_user(user_id)
         .await
         .map_err(|e| UserFlowError::Database(e.to_string()))?
         .ok_or_else(|| UserFlowError::UserNotFound(user_id.to_string()))?;
+
+    tracing::debug!("Deleting user account: {:#?}", user);
 
     // Delete all OAuth2 accounts for this user
     OAuth2Store::delete_oauth2_accounts_by(AccountSearchField::UserId(user_id.to_string()))

--- a/libauth/src/user_flow.rs
+++ b/libauth/src/user_flow.rs
@@ -1,0 +1,68 @@
+use liboauth2::{AccountSearchField, OAuth2Store};
+use libpasskey::{CredentialSearchField, PasskeyStore};
+use libuserdb::{User, UserStore};
+use thiserror::Error;
+
+/// Errors that can occur during user account operations
+#[derive(Error, Debug)]
+pub enum UserFlowError {
+    #[error("User not found: {0}")]
+    UserNotFound(String),
+    #[error("Database error: {0}")]
+    Database(String),
+    #[error("Credential not found: {0}")]
+    CredentialNotFound(String),
+    #[error("OAuth2 account not found: {0}")]
+    OAuth2AccountNotFound(String),
+}
+
+/// Update a user's account and label
+pub async fn update_user_account(
+    user_id: &str,
+    account: Option<String>,
+    label: Option<String>,
+) -> Result<User, UserFlowError> {
+    // Get the current user
+    let user = UserStore::get_user(user_id)
+        .await
+        .map_err(|e| UserFlowError::Database(e.to_string()))?
+        .ok_or_else(|| UserFlowError::UserNotFound(user_id.to_string()))?;
+
+    // Update the user with the new values
+    let updated_user = User {
+        account: account.unwrap_or(user.account),
+        label: label.unwrap_or(user.label),
+        ..user
+    };
+
+    // Save the updated user
+    UserStore::upsert_user(updated_user)
+        .await
+        .map_err(|e| UserFlowError::Database(e.to_string()))
+}
+
+/// Delete a user account and all associated OAuth2 accounts and Passkey credentials
+pub async fn delete_user_account(user_id: &str) -> Result<(), UserFlowError> {
+    // Check if the user exists
+    let _user = UserStore::get_user(user_id)
+        .await
+        .map_err(|e| UserFlowError::Database(e.to_string()))?
+        .ok_or_else(|| UserFlowError::UserNotFound(user_id.to_string()))?;
+
+    // Delete all OAuth2 accounts for this user
+    OAuth2Store::delete_oauth2_accounts_by(AccountSearchField::UserId(user_id.to_string()))
+        .await
+        .map_err(|e| UserFlowError::Database(e.to_string()))?;
+
+    // Delete all Passkey credentials for this user
+    PasskeyStore::delete_credential_by(CredentialSearchField::UserId(user_id.to_string()))
+        .await
+        .map_err(|e| UserFlowError::Database(e.to_string()))?;
+
+    // Finally, delete the user account
+    UserStore::delete_user(user_id)
+        .await
+        .map_err(|e| UserFlowError::Database(e.to_string()))?;
+
+    Ok(())
+}

--- a/libaxum/Cargo.toml
+++ b/libaxum/Cargo.toml
@@ -19,5 +19,6 @@ axum = { workspace = true }
 axum-extra = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 urlencoding = { workspace = true }

--- a/libaxum/src/lib.rs
+++ b/libaxum/src/lib.rs
@@ -4,7 +4,7 @@ mod session;
 mod summary;
 
 pub use oauth2::router as oauth2_router;
-pub use passkey::related_origin_router;
+pub use passkey::passkey_well_known_router;
 pub use passkey::router as passkey_router;
 pub use session::AuthUser;
 pub use summary::router as summary_router;

--- a/libaxum/src/passkey/mod.rs
+++ b/libaxum/src/passkey/mod.rs
@@ -1,4 +1,4 @@
 mod handlers;
 mod routes;
 
-pub use routes::{related_origin_router, router};
+pub use routes::{passkey_well_known_router, router};

--- a/libaxum/src/passkey/routes.rs
+++ b/libaxum/src/passkey/routes.rs
@@ -1,9 +1,9 @@
-use axum::routing::{Router, get, post};
+use axum::routing::{Router, delete, get, post};
 
 use super::handlers::{
-    conditional_ui, handle_finish_authentication, handle_finish_registration,
-    handle_start_authentication, handle_start_registration_post, list_passkey_credentials,
-    serve_conditional_ui_js, serve_passkey_js, serve_related_origin,
+    conditional_ui, delete_passkey_credential, handle_finish_authentication,
+    handle_finish_registration, handle_start_authentication, handle_start_registration_post,
+    list_passkey_credentials, serve_conditional_ui_js, serve_passkey_js, serve_related_origin,
 };
 
 pub fn router() -> Router {
@@ -14,6 +14,10 @@ pub fn router() -> Router {
         .nest("/auth", router_auth())
         .nest("/register", router_register())
         .route("/credentials", get(list_passkey_credentials))
+        .route(
+            "/credentials/{credential_id}",
+            delete(delete_passkey_credential),
+        )
 }
 
 pub fn router_register() -> Router {
@@ -30,6 +34,6 @@ pub fn router_auth() -> Router {
 
 /// Creates a router for the WebAuthn well-known endpoint
 /// This should be mounted at the root level of the application
-pub fn related_origin_router() -> Router {
-    Router::new().route("/.well-known/webauthn", get(serve_related_origin))
+pub fn passkey_well_known_router() -> Router {
+    Router::new().route("/webauthn", get(serve_related_origin))
 }

--- a/libaxum/src/summary/handlers.rs
+++ b/libaxum/src/summary/handlers.rs
@@ -1,9 +1,10 @@
 use askama::Template;
 use axum::{
     Router,
+    extract::Json as ExtractJson,
     http::StatusCode,
     response::{Html, Json},
-    routing::get,
+    routing::{delete, get},
 };
 
 use libauth::{list_accounts_core, list_credentials_core};
@@ -20,6 +21,7 @@ pub fn router() -> Router<()> {
     Router::new()
         .route("/", get(user_summary))
         .route("/user-info", get(user_info))
+        .route("/user/delete", delete(delete_user_account_handler))
 }
 
 /// Return basic user information as JSON for the client-side JavaScript
@@ -52,6 +54,53 @@ pub async fn user_info(auth_user: Option<AuthUser>) -> Result<Json<Value>, (Stat
             Err((StatusCode::UNAUTHORIZED, "Not authenticated".to_string()))
         }
     }
+}
+
+/// Delete the authenticated user's account and all associated data
+///
+/// This endpoint requires authentication and will delete:
+/// 1. All OAuth2 accounts linked to the user
+/// 2. All Passkey credentials registered by the user
+/// 3. The user account itself
+///
+/// After successful deletion, the client should redirect to the logout endpoint
+/// to clear the session.
+#[derive(serde::Deserialize)]
+pub struct DeleteUserRequest {
+    user_id: String,
+}
+
+pub async fn delete_user_account_handler(
+    auth_user: AuthUser,
+    ExtractJson(payload): ExtractJson<DeleteUserRequest>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    // Get the user ID from the authenticated user
+    let session_user_id = auth_user.id.clone();
+    let request_user_id = payload.user_id;
+
+    // Verify that the user ID in the request matches the session user ID
+    if session_user_id != request_user_id {
+        tracing::warn!(
+            "User ID mismatch in delete request: session={}, request={}",
+            session_user_id,
+            request_user_id
+        );
+        return Err((
+            StatusCode::FORBIDDEN,
+            "Cannot delete another user's account".to_string(),
+        ));
+    }
+
+    tracing::debug!("Deleting user account: {}", session_user_id);
+
+    // Call the core function to delete the user account and all associated data
+    // Using the imported function from libauth
+    libauth::delete_user_account(&session_user_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Return a success status code
+    Ok(StatusCode::OK)
 }
 
 /// Display a comprehensive summary page with user info, passkey credentials, and OAuth2 accounts

--- a/libaxum/templates/user_summary.j2
+++ b/libaxum/templates/user_summary.j2
@@ -188,7 +188,10 @@
 <body>
     <div class="page-header">
         <h1>User Summary</h1>
-        <button onclick="Logout()" class="action-button">Logout</button>
+        <div class="header-buttons">
+            <button onclick="Logout()" class="action-button">Logout</button>
+            <button onclick="DeleteAccount()" class="action-button delete-button">Delete Account</button>
+        </div>
     </div>
 
     <!-- User Information Section -->
@@ -274,11 +277,38 @@
         {% endif %}
     </div>
 
-    <!-- Removed duplicate buttons as they're now in the section headers -->
-
     <script>
         function Logout() {
             window.location.href = "{{auth_route_prefix}}/logout";
+        }
+
+        function DeleteAccount() {
+            // Include account name in confirmation for better verification
+            const accountName = "{{user.account}}";
+            const userId = "{{user.id}}";
+            if (confirm(`Are you sure you want to delete your account "${accountName}"? This action cannot be undone and will delete all your data including OAuth2 accounts and passkey credentials.`)) {
+                fetch(`/summary/user/delete`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ user_id: userId })
+                })
+                .then(response => {
+                    if (response.ok) {
+                        alert('Your account has been deleted. You will now be logged out.');
+                        // Redirect to logout to clear the session
+                        window.location.reload();
+                    } else {
+                        response.text().then(text => {
+                            alert(`Failed to delete account: ${text}`);
+                        });
+                    }
+                })
+                .catch(error => {
+                    alert(`Error: ${error.message}`);
+                });
+            }
         }
 
         function unlinkOAuth2Account(provider, providerUserId) {

--- a/libaxum/templates/user_summary.j2
+++ b/libaxum/templates/user_summary.j2
@@ -112,6 +112,30 @@
         .action-button:hover {
             background-color: #3367d6;
         }
+        
+        .delete-button {
+            background-color: #f44336;
+            color: white;
+            border: none;
+            padding: 5px 10px;
+            text-align: center;
+            text-decoration: none;
+            display: inline-block;
+            font-size: 14px;
+            margin: 4px 2px;
+            cursor: pointer;
+            border-radius: 4px;
+        }
+        
+        .delete-button:hover {
+            background-color: #d32f2f;
+        }
+        
+        .created-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
         /* Responsive adjustments */
         @media screen and (max-width: 600px) {
             html, body {
@@ -192,9 +216,13 @@
         {% else %}
             {% for credential in passkey_credentials %}
                 <div class="item">
+                    <div class="item-detail"><strong>Credential ID:</strong> {{ credential.credential_id }}</div>
                     <div class="item-detail"><strong>User Name:</strong> {{ credential.user_name }}</div>
                     <div class="item-detail"><strong>Display Name:</strong> {{ credential.user_display_name }}</div>
-                    <div class="item-detail"><strong>Created:</strong> {{ credential.created_at }}</div>
+                    <div class="item-detail created-row">
+                        <span><strong>Created:</strong> {{ credential.created_at }}</span>
+                        <button onclick="deletePasskeyCredential('{{ credential.credential_id }}')" class="delete-button">Unlink</button>
+                    </div>
                     <!--
                     <div class="item-detail"><strong>Credential ID:</strong> {{ credential.credential_id }}</div>
                     <div class="item-detail"><strong>Updated:</strong> {{ credential.updated_at }}</div>
@@ -237,7 +265,10 @@
                         <div class="item-detail"><strong>Email:</strong> {{ account.email }}</div>
                     {% endif %}
                     <div class="item-detail"><strong>Name:</strong> {{ account.name }}</div>
-                    <div class="item-detail"><strong>Created:</strong> {{ account.created_at }}</div>
+                    <div class="item-detail created-row">
+                        <span><strong>Created:</strong> {{ account.created_at }}</span>
+                        <button onclick="unlinkOAuth2Account('{{ account.provider }}', '{{ account.provider_user_id }}')" class="delete-button">Unlink</button>
+                    </div>
                 </div>
             {% endfor %}
         {% endif %}
@@ -248,6 +279,54 @@
     <script>
         function Logout() {
             window.location.href = "{{auth_route_prefix}}/logout";
+        }
+
+        function unlinkOAuth2Account(provider, providerUserId) {
+            if (confirm('Are you sure you want to unlink this OAuth2 account?')) {
+                fetch(`${AUTH_ROUTE_PREFIX}/accounts/${provider}/${providerUserId}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                })
+                .then(response => {
+                    if (response.ok) {
+                        // Refresh the page to show updated account list
+                        window.location.reload();
+                    } else {
+                        response.text().then(text => {
+                            alert(`Failed to unlink account: ${text}`);
+                        });
+                    }
+                })
+                .catch(error => {
+                    alert(`Error: ${error.message}`);
+                });
+            }
+        }
+        
+        function deletePasskeyCredential(credentialId) {
+            if (confirm('Are you sure you want to unlink this passkey credential?')) {
+                fetch(`${PASSKEY_ROUTE_PREFIX}/credentials/${credentialId}`, {
+                    method: 'DELETE',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                })
+                .then(response => {
+                    if (response.ok) {
+                        // Refresh the page to show updated credential list
+                        window.location.reload();
+                    } else {
+                        response.text().then(text => {
+                            alert(`Failed to unlink passkey credential: ${text}`);
+                        });
+                    }
+                })
+                .catch(error => {
+                    alert(`Error: ${error.message}`);
+                });
+            }
         }
     </script>
 

--- a/libaxum/templates/user_summary.j2
+++ b/libaxum/templates/user_summary.j2
@@ -136,6 +136,32 @@
             justify-content: space-between;
             align-items: center;
         }
+
+        .form-group {
+            margin-bottom: 15px;
+        }
+
+        .form-input {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            font-size: 14px;
+        }
+
+        .form-actions {
+            display: flex;
+            gap: 10px;
+            margin-top: 15px;
+        }
+
+        .secondary-button {
+            background-color: #95a5a6;
+        }
+
+        .secondary-button:hover {
+            background-color: #7f8c8d;
+        }
         /* Responsive adjustments */
         @media screen and (max-width: 600px) {
             html, body {
@@ -196,15 +222,35 @@
 
     <!-- User Information Section -->
     <div class="section">
-        <h2 class="section-title">User Information</h2>
-        <div class="item">
+        <div class="section-header">
+            <h2 class="section-title">User Information</h2>
+            <button onclick="toggleEditUserForm()" class="action-button">Edit Profile</button>
+        </div>
+        <div class="item" id="user-info-display">
             <div class="item-detail"><strong>User ID:</strong> {{ user.id }}</div>
-            <div class="item-detail"><strong>Account:</strong> {{ user.account }}</div>
-            <div class="item-detail"><strong>Label:</strong> {{ user.label }}</div>
+            <div class="item-detail"><strong>Account:</strong> <span id="display-account">{{ user.account }}</span></div>
+            <div class="item-detail"><strong>Label:</strong> <span id="display-label">{{ user.label }}</span></div>
             <div class="item-detail"><strong>Created:</strong> {{ user.created_at }}</div>
             <!--
             <div class="item-detail"><strong>Updated:</strong> {{ user.updated_at }}</div>
             -->
+        </div>
+        <div class="item" id="user-edit-form" style="display: none;">
+            <form id="update-user-form">
+                <input type="hidden" id="edit-user-id" value="{{ user.id }}">
+                <div class="form-group">
+                    <label for="edit-account">Account:</label>
+                    <input type="text" id="edit-account" value="{{ user.account }}" class="form-input">
+                </div>
+                <div class="form-group">
+                    <label for="edit-label">Label:</label>
+                    <input type="text" id="edit-label" value="{{ user.label }}" class="form-input">
+                </div>
+                <div class="form-actions">
+                    <button type="button" onclick="updateUserAccount()" class="action-button">Save</button>
+                    <button type="button" onclick="toggleEditUserForm()" class="action-button secondary-button">Cancel</button>
+                </div>
+            </form>
         </div>
     </div>
 
@@ -280,6 +326,59 @@
     <script>
         function Logout() {
             window.location.href = "{{auth_route_prefix}}/logout";
+        }
+
+        function toggleEditUserForm() {
+            const displayDiv = document.getElementById('user-info-display');
+            const editForm = document.getElementById('user-edit-form');
+
+            if (editForm.style.display === 'none') {
+                displayDiv.style.display = 'none';
+                editForm.style.display = 'block';
+            } else {
+                displayDiv.style.display = 'block';
+                editForm.style.display = 'none';
+            }
+        }
+
+        function updateUserAccount() {
+            const userId = document.getElementById('edit-user-id').value;
+            const account = document.getElementById('edit-account').value;
+            const label = document.getElementById('edit-label').value;
+
+            fetch(`/summary/user/update`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    user_id: userId,
+                    account: account,
+                    label: label
+                })
+            })
+            .then(response => {
+                if (!response.ok) {
+                    return response.text().then(text => {
+                        throw new Error(text);
+                    });
+                }
+                return response.json();
+            })
+            .then(data => {
+                // Update the display with the new values
+                document.getElementById('display-account').textContent = data.account;
+                document.getElementById('display-label').textContent = data.label;
+
+                // Show a success message
+                alert('Profile updated successfully');
+
+                // Toggle back to display view
+                toggleEditUserForm();
+            })
+            .catch(error => {
+                alert(`Error updating profile: ${error.message}`);
+            });
         }
 
         function DeleteAccount() {

--- a/liboauth2/src/lib.rs
+++ b/liboauth2/src/lib.rs
@@ -17,7 +17,7 @@ pub use oauth2::{
     get_uid_from_stored_session_by_state_param, prepare_oauth2_auth_request, validate_origin,
 };
 pub use storage::OAuth2Store;
-pub use types::{AuthResponse, OAuth2Account, StateParams};
+pub use types::{AccountSearchField, AuthResponse, OAuth2Account, StateParams};
 
 pub async fn init() -> Result<(), errors::OAuth2Error> {
     // Validate required environment variables early

--- a/liboauth2/src/types.rs
+++ b/liboauth2/src/types.rs
@@ -144,3 +144,21 @@ impl TryFrom<libstorage::CacheData> for StoredToken {
         serde_json::from_slice(&data.value).map_err(|e| OAuth2Error::Storage(e.to_string()))
     }
 }
+
+/// Search field options for credential lookup
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum AccountSearchField {
+    /// Search by ID
+    Id(String),
+    /// Search by user ID (database ID)
+    UserId(String),
+    /// Search by provider
+    Provider(String),
+    /// Search by provider user ID
+    ProviderUserId(String),
+    /// Search by name
+    Name(String),
+    /// Search by email
+    Email(String),
+}

--- a/libpasskey/src/passkey/auth.rs
+++ b/libpasskey/src/passkey/auth.rs
@@ -119,6 +119,11 @@ pub async fn finish_authentication(
             PasskeyError::NotFound("Credential not found".into())
         })?;
 
+    tracing::debug!(
+        "finish_authentication: Credential &id: {:?}, id: {}",
+        &auth_response.id,
+        auth_response.id
+    );
     tracing::debug!("Found credential: {:?}", stored_credential);
     tracing::debug!(
         "Credential properties:\n\

--- a/libpasskey/src/types.rs
+++ b/libpasskey/src/types.rs
@@ -53,6 +53,7 @@ pub(super) struct SessionInfo {
 #[derive(Debug)]
 pub enum CredentialSearchField {
     /// Search by credential ID
+    // CredentialId(Vec<u8>),
     CredentialId(String),
     /// Search by user ID (database ID)
     UserId(String),


### PR DESCRIPTION
Core functionality:
- Add ability to delete OAuth2 accounts with proper ownership verification
- Add ability to delete Passkey credentials with hex/binary ID conversion handling
- Create new user_flow module with account update and deletion capabilities
- Implement cascading deletion (removing associated credentials when deleting users)

API and routing changes:
- Rename related_origin_router to passkey_well_known_router for clarity
- Change WebAuthn endpoint mounting from merge to nest for consistency
- Add new API endpoints for account/credential deletion
- Re-export OAuth2Store and PasskeyStore types from libauth

Storage layer enhancements:
- Add AccountSearchField enum for flexible OAuth2 account queries
- Implement delete_oauth2_accounts_by and delete_credential_by methods
- Add support for deleting users and their associated data
- Refactor get_oauth2_accounts to use the new field-based search

UI improvements:
- Add delete buttons to OAuth2 accounts and Passkey credentials in summary page
- Implement JavaScript functions for account/credential deletion with confirmation
- Display credential IDs in the UI for better identification
- Improve layout with created-row styling for better button placement

Dependencies:
- Add base64 and hex dependencies to libauth for credential ID handling