### PR TITLE
feat(passkey): Improve user handle management and credential syncing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,10 +8,18 @@
   - Use Base64 URL_SAFE_NO_PAD consistently for all credential IDs and public keys
   - Update database schema and existing records if necessary
   - We'll do this after the tests are implemented
-- Passkey sync between RP and Authenticator using Signal API.
+
+- [Need to investigate] Passkey sync between RP and Authenticator using signalCurrentUserDetails not working.
+
+## Half Done
+
+- [Need to investigate] I'm wondering if we should stop creating new user_handle everytime we create a new passkey credential.Instead we might have to use the existing user_handle for a logged in user. This will align well with syncing of credentials using the signalAllAcceptedCredentials.
+  - We can now control this by setting PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL environment variable.
+  - By having user_handle unique for user i.e. not for every credential, we seem to be able to only register one passkey credential per user in Google Password Manager.
 
 ## Done
 
+- ~~Passkey sync between RP and Authenticator using signalAllAcceptedCredentials.~~
 - ~~Enable modification of User.account and User.label for logged in user.~~
 - ~~Enable deletion of logged in user then logout.~~
 
@@ -23,3 +31,10 @@
 (https://passkeys.dev/docs/advanced/related-origins/)~~
 - ~~Use parseCreationOptionsFromJSON and parseAuthenticationOptionsFromJSON to simplify passkey.js implementation.~~ Won't do as this requires webauthn-json dependency.
 - ~~Deal with halfway registration and authentication in passkey.js.~~
+
+## Memo
+
+```text
+Can you take a look the following diff and if we aren't introducing any bugs and every change is OK suggest a commit message plz.
+
+```

--- a/libaxum/templates/user_summary.j2
+++ b/libaxum/templates/user_summary.j2
@@ -442,78 +442,36 @@
         // This helps keep the authenticator's credential store in sync with the server
         // Takes the user handle of the deleted credential as a parameter
         function synchronizeCredentials(userHandle) {
-            try {
-                // Check if the WebAuthn API is available
-                if (!window.PublicKeyCredential) {
-                    console.log('WebAuthn credential management API not available');
-                    return;
-                }
-
-                console.log('PublicKeyCredential is available');
-
-                // Check if signalAllAcceptedCredentials is available
-                if (typeof window.PublicKeyCredential.signalAllAcceptedCredentials !== 'function') {
-                    console.log('WebAuthn credential management API not supported in this browser');
-                    return;
-                }
-
-                console.log('signalAllAcceptedCredentials API is available');
-                console.log('Using signalAllAcceptedCredentials with empty array for credential deletion');
-
-                // Use the user handle provided from the deleted credential
-                // This is more accurate than fetching it from another credential
-                if (!userHandle) {
-                    // If no user handle was provided, use a fallback
-                    userHandle = 'user';
-                    console.log('No user handle provided, using fallback:', userHandle);
-                } else {
-                    console.log('Using user handle from deleted credential:', userHandle);
-                }
-
-                // Encode the user handle in base64url format
-                const userIdBytes = new TextEncoder().encode(userHandle);
-                const userIdBase64Url = arrayBufferToBase64URL(userIdBytes.buffer);
-
-                console.log('Using base64url encoded userId:', userIdBase64Url);
-                console.log('Using empty array for credentials to signal deletion');
-
-                // Signal all accepted credentials with an empty array
-                // This tells the authenticator that no credentials are valid for this user and RP
-                return window.PublicKeyCredential.signalAllAcceptedCredentials({
-                    rpId: window.location.hostname,
-                    userId: userIdBase64Url,
-                    allAcceptedCredentialIds: [] // Empty array = no valid credentials
-                })
-                .then(() => {
-                    console.log('Successfully signaled credential deletion to authenticator');
-                })
-                .catch(err => {
-                    console.warn('Error during credential synchronization:', err);
-
-                    // Fallback to a generic user handle if we can't fetch credentials
-                    const fallbackUserHandle = 'user';
-                    const fallbackUserIdBytes = new TextEncoder().encode(fallbackUserHandle);
-                    const fallbackUserIdBase64Url = arrayBufferToBase64URL(fallbackUserIdBytes.buffer);
-
-                    console.log('Using fallback user handle due to error');
-
-                    // Try with the fallback user handle
-                    return window.PublicKeyCredential.signalAllAcceptedCredentials({
-                        rpId: window.location.hostname,
-                        userId: fallbackUserIdBase64Url,
-                        allAcceptedCredentialIds: [] // Empty array = no valid credentials
-                    })
-                    .then(() => {
-                        console.log('Successfully signaled credential deletion with fallback user handle');
-                    })
-                    .catch(err => {
-                        console.warn('Error signaling credential deletion with fallback:', err);
-                    });
-                });
-            } catch (err) {
-                console.warn('Unexpected error during credential synchronization:', err);
-                return Promise.resolve(); // Return a resolved promise to allow chaining
+            // Check if the WebAuthn API and signalAllAcceptedCredentials are available
+            if (!window.PublicKeyCredential ||
+                typeof window.PublicKeyCredential.signalAllAcceptedCredentials !== 'function') {
+                console.log('WebAuthn credential management API not available or not supported');
+                return Promise.resolve(); // Return resolved promise for chaining
             }
+
+            // Exit early if no user handle is provided
+            if (!userHandle) {
+                console.log('No user handle provided, skipping credential synchronization');
+                return Promise.resolve();
+            }
+
+            // Encode the user handle in base64url format
+            const userIdBytes = new TextEncoder().encode(userHandle);
+            const userIdBase64Url = arrayBufferToBase64URL(userIdBytes.buffer);
+
+            // Signal all accepted credentials with an empty array
+            // This tells the authenticator that no credentials are valid for this user and RP
+            return window.PublicKeyCredential.signalAllAcceptedCredentials({
+                rpId: window.location.hostname,
+                userId: userIdBase64Url,
+                allAcceptedCredentialIds: [] // Empty array = no valid credentials
+            })
+            .then(() => {
+                console.log('Successfully signaled credential deletion to authenticator');
+            })
+            .catch(err => {
+                console.warn('Error during credential synchronization:', err);
+            });
         }
 
         // Function to synchronize credentials with the authenticator using signalUnknownCredential

--- a/libpasskey/src/common.rs
+++ b/libpasskey/src/common.rs
@@ -45,7 +45,7 @@ pub fn gen_random_string(len: usize) -> Result<String, PasskeyError> {
     let mut session_id = vec![0u8; len];
     rng.fill(&mut session_id)
         .map_err(|_| PasskeyError::Crypto("Failed to generate random string".to_string()))?;
-    Ok(URL_SAFE.encode(session_id))
+    Ok(URL_SAFE_NO_PAD.encode(session_id))
 }
 
 pub(crate) async fn get_credential_id_strs_by(

--- a/libpasskey/src/config.rs
+++ b/libpasskey/src/config.rs
@@ -101,3 +101,10 @@ pub(crate) static PASSKEY_USER_VERIFICATION: LazyLock<String> = LazyLock::new(||
         },
     )
 });
+
+pub(crate) static PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL: LazyLock<bool> =
+    LazyLock::new(|| {
+        env::var("PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL")
+            .map(|v| v.parse::<bool>().unwrap_or(true))
+            .unwrap_or(true)
+    });


### PR DESCRIPTION
Implement configurable user handle management for passkey credentials to better support credential syncing across devices:

- Add PASSKEY_USER_HANDLE_UNIQUE_FOR_EVERY_CREDENTIAL environment variable to control whether each credential gets a unique user handle
- Refactor registration process to reuse existing user handles for logged-in users when appropriate
- Simplify credential synchronization JavaScript code for better maintainability
- Use URL_SAFE_NO_PAD consistently for base64 encoding

This change addresses the issue where creating new user handles for every passkey credential could prevent proper syncing between relying parties and authenticators.