### PR TITLE
refactor(passkey): Simplify challenge generation and base64 encoding

### DIFF
--- a/libauth/src/passkey_flow.rs
+++ b/libauth/src/passkey_flow.rs
@@ -221,32 +221,19 @@ pub async fn delete_passkey_credential_core(
         }
     };
 
-    // The credential_id from the UI is in hex format, but in the database it's stored directly as a string
-    // So we need to use it directly without conversion
     tracing::debug!("Attempting to delete credential with ID: {}", credential_id);
 
-    // Get all credentials for this user to find the matching one
-    let user_credentials =
-        PasskeyStore::get_credentials_by(CredentialSearchField::UserId(user.id.to_owned()))
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    tracing::debug!("Found {} credentials for user", user_credentials.len());
-
-    // Find the credential with the matching ID
-    let credential = user_credentials
-        .into_iter()
-        .find(|c| {
-            // The credential_id in the UI is displayed in hex format, so we need to convert
-            // the binary credential_id from the database to hex for comparison
-            let hex_id = hex::encode(&c.credential_id);
-            tracing::debug!("Comparing credential ID: {} with {}", hex_id, credential_id);
-            hex_id == credential_id
-        })
-        .ok_or((
-            StatusCode::NOT_FOUND,
-            "Passkey credential not found".to_string(),
-        ))?;
+    let credential = PasskeyStore::get_credentials_by(CredentialSearchField::CredentialId(
+        credential_id.to_owned(),
+    ))
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    .into_iter()
+    .next()
+    .ok_or((
+        StatusCode::NOT_FOUND,
+        format!("Credential not found with ID: {}", credential_id),
+    ))?;
 
     // Verify the credential belongs to the authenticated user
     if credential.user_id != user.id {
@@ -256,31 +243,15 @@ pub async fn delete_passkey_credential_core(
         ));
     }
 
-    // The credential ID in the database is stored directly as a string
-    // We need to use the exact credential ID as it appears in the database
-
-    // Get the raw credential ID string from the database record
-    let raw_credential_id = std::str::from_utf8(&credential.credential_id)
-        .map_err(|_| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Invalid credential ID encoding".to_string(),
-            )
-        })?
-        .to_string();
-
-    tracing::debug!(
-        "Deleting credential with raw database ID: {}",
-        raw_credential_id
-    );
-
     // Delete the credential using the raw credential ID format from the database
-    PasskeyStore::delete_credential_by(CredentialSearchField::CredentialId(raw_credential_id))
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete credential: {}", e);
-            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-        })?;
+    PasskeyStore::delete_credential_by(CredentialSearchField::CredentialId(
+        credential.credential_id.clone(),
+    ))
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to delete credential: {}", e);
+        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
 
     tracing::debug!("Successfully deleted credential");
 

--- a/libaxum/src/summary/handlers.rs
+++ b/libaxum/src/summary/handlers.rs
@@ -179,27 +179,15 @@ pub async fn user_summary(auth_user: AuthUser) -> Result<Html<String>, (StatusCo
     // Convert StoredCredential to TemplateCredential
     let passkey_credentials = stored_credentials
         .into_iter()
-        .map(|cred| {
-            // Convert Vec<u8> to hex string representation for consistency
-            let credential_id_hex = cred.credential_id.iter().fold(
-                String::with_capacity(cred.credential_id.len() * 2),
-                |mut acc, b| {
-                    use std::fmt::Write;
-                    let _ = write!(acc, "{:02x}", b);
-                    acc
-                },
-            );
-
-            TemplateCredential {
-                credential_id: credential_id_hex,
-                user_id: cred.user_id.clone(),
-                user_name: cred.user.name.clone(),
-                user_display_name: cred.user.display_name.clone(),
-                user_handle: cred.user.user_handle.clone(),
-                counter: cred.counter.to_string(),
-                created_at: cred.created_at.to_string(),
-                updated_at: cred.updated_at.to_string(),
-            }
+        .map(|cred| TemplateCredential {
+            credential_id: cred.credential_id,
+            user_id: cred.user_id.clone(),
+            user_name: cred.user.name.clone(),
+            user_display_name: cred.user.display_name.clone(),
+            user_handle: cred.user.user_handle.clone(),
+            counter: cred.counter.to_string(),
+            created_at: cred.created_at.to_string(),
+            updated_at: cred.updated_at.to_string(),
         })
         .collect();
 

--- a/libaxum/static/passkey.js
+++ b/libaxum/static/passkey.js
@@ -49,7 +49,7 @@ async function startAuthentication(withUsername = false) {
             console.log('Raw credentials:', options.allowCredentials);
             options.allowCredentials = options.allowCredentials.map(credential => ({
                 type: 'public-key',  // Required by WebAuthn
-                id: new Uint8Array(credential.id),
+                id: base64URLToUint8Array(credential.id),
                 transports: credential.transports  // Optional
             }));
             console.log('Processed credentials:', options.allowCredentials);

--- a/libpasskey/src/common.rs
+++ b/libpasskey/src/common.rs
@@ -50,7 +50,6 @@ pub(crate) async fn get_credential_id_strs_by(
         .into_iter()
         .map(|cred| UserIdCredentialIdStr {
             user_id: cred.user_id,
-            credential_id_str: URL_SAFE_NO_PAD.encode(&cred.credential_id),
             credential_id: cred.credential_id,
         })
         .collect();

--- a/libpasskey/src/passkey/register.rs
+++ b/libpasskey/src/passkey/register.rs
@@ -203,10 +203,6 @@ pub async fn finish_registration(
 
     let public_key = extract_credential_public_key(reg_data)?;
 
-    // Decode and store credential
-    let credential_id = base64url_decode(&reg_data.raw_id)
-        .map_err(|e| PasskeyError::Format(format!("Failed to decode credential ID: {}", e)))?;
-
     let user_handle = reg_data
         .user_handle
         .as_deref()
@@ -220,7 +216,7 @@ pub async fn finish_registration(
     let credential_id_str = reg_data.raw_id.clone();
 
     let credential = StoredCredential {
-        credential_id,
+        credential_id: credential_id_str.clone(),
         user_id: user_id.to_string(),
         public_key,
         counter: 0,

--- a/libpasskey/src/passkey/register.rs
+++ b/libpasskey/src/passkey/register.rs
@@ -1,7 +1,3 @@
-use base64::engine::{
-    Engine,
-    general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
-};
 use chrono::Utc;
 use ciborium::value::{Integer, Value as CborValue};
 
@@ -14,8 +10,7 @@ use super::types::{
 };
 
 use crate::common::{
-    base64url_decode, gen_random_string, generate_challenge, get_from_cache, remove_from_cache,
-    store_in_cache,
+    base64url_decode, gen_random_string, get_from_cache, remove_from_cache, store_in_cache,
 };
 use crate::config::{
     ORIGIN, PASSKEY_AUTHENTICATOR_ATTACHMENT, PASSKEY_CHALLENGE_TIMEOUT,
@@ -115,9 +110,9 @@ pub async fn start_registration(
 pub async fn create_registration_options(
     user_info: PublicKeyCredentialUserEntity,
 ) -> Result<RegistrationOptions, PasskeyError> {
-    let challenge = generate_challenge();
+    let challenge_str = gen_random_string(32)?;
     let stored_challenge = StoredOptions {
-        challenge: challenge.clone().unwrap_or_default(),
+        challenge: challenge_str.clone(),
         user: user_info.clone(),
         timestamp: std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -142,7 +137,7 @@ pub async fn create_registration_options(
     };
 
     let options = RegistrationOptions {
-        challenge: URL_SAFE.encode(challenge.unwrap_or_default()),
+        challenge: challenge_str,
         rp_id: PASSKEY_RP_ID.to_string(),
         rp: RelyingParty {
             name: PASSKEY_RP_NAME.to_string(),
@@ -202,7 +197,7 @@ pub async fn finish_registration(
     user_id: &str,
     reg_data: &RegisterCredential,
 ) -> Result<String, PasskeyError> {
-    println!("finish_registration user: {:?}", reg_data);
+    tracing::debug!("finish_registration user: {:?}", reg_data);
 
     verify_client_data(reg_data).await?;
 
@@ -461,12 +456,11 @@ async fn verify_client_data(reg_data: &RegisterCredential) -> Result<(), Passkey
     let stored_options = get_and_validate_options("regi_challenge", user_handle).await?;
 
     // Step 8: Verify challenge using base64url encoding comparison
-    let stored_challenge = URL_SAFE_NO_PAD.encode(&stored_options.challenge);
-    if client_data.challenge != stored_challenge {
+    if client_data.challenge != stored_options.challenge {
         tracing::error!(
             "Challenge verification failed: client_data.challenge: {}, stored_options.challenge: {}",
             client_data.challenge,
-            stored_challenge
+            stored_options.challenge
         );
         return Err(PasskeyError::Challenge(
             "Challenge verification failed".to_string(),

--- a/libpasskey/src/passkey/types.rs
+++ b/libpasskey/src/passkey/types.rs
@@ -17,7 +17,7 @@ pub struct AuthenticationOptions {
 #[derive(Serialize, Debug)]
 pub(super) struct AllowCredential {
     pub(super) type_: String,
-    pub(super) id: Vec<u8>,
+    pub(super) id: String,
 }
 
 #[derive(Serialize, Debug, Clone, Deserialize)]

--- a/libpasskey/src/passkey/types.rs
+++ b/libpasskey/src/passkey/types.rs
@@ -119,7 +119,7 @@ pub(super) struct AttestationObject {
 
 #[derive(Debug)]
 pub(super) struct ParsedClientData {
-    pub(super) challenge: Vec<u8>,
+    pub(super) challenge: String,
     pub(super) origin: String,
     pub(super) type_: String,
     pub(super) raw_data: Vec<u8>,

--- a/libpasskey/src/storage/passkey_store.rs
+++ b/libpasskey/src/storage/passkey_store.rs
@@ -451,7 +451,7 @@ impl<'r> FromRow<'r, SqliteRow> for StoredCredential {
         let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
 
         Ok(StoredCredential {
-            credential_id: credential_id.as_bytes().to_vec(),
+            credential_id,
             user_id,
             public_key,
             counter: counter as u32,
@@ -480,7 +480,7 @@ impl<'r> FromRow<'r, PgRow> for StoredCredential {
         let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
 
         Ok(StoredCredential {
-            credential_id: credential_id.as_bytes().to_vec(),
+            credential_id,
             user_id,
             public_key,
             counter: counter as u32,

--- a/libpasskey/src/types.rs
+++ b/libpasskey/src/types.rs
@@ -21,7 +21,7 @@ pub(super) struct StoredOptions {
 /// Stored credential information for a passkey
 pub struct StoredCredential {
     /// Raw credential ID bytes
-    pub credential_id: Vec<u8>,
+    pub credential_id: String,
     /// User ID associated with this credential (database ID)
     pub user_id: String,
     /// Public key bytes for the credential
@@ -39,8 +39,7 @@ pub struct StoredCredential {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub(super) struct UserIdCredentialIdStr {
     pub(super) user_id: String,
-    pub(super) credential_id_str: String,
-    pub(super) credential_id: Vec<u8>,
+    pub(super) credential_id: String,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/libpasskey/src/types.rs
+++ b/libpasskey/src/types.rs
@@ -11,7 +11,7 @@ pub struct PublicKeyCredentialUserEntity {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub(super) struct StoredOptions {
-    pub(super) challenge: Vec<u8>,
+    pub(super) challenge: String,
     pub(super) user: PublicKeyCredentialUserEntity,
     pub(super) timestamp: u64,
     pub(super) ttl: u64,


### PR DESCRIPTION
Improve challenge and random string generation with more consistent and streamlined approach:

- Use `URL_SAFE_NO_PAD` consistently for base64 encoding and decoding
- Remove unnecessary base64 padding logic
- Replace challenge generation with [gen_random_string()](cci:1://file:///home/ktaka/GitHub/axum-oauth2-passkey/libpasskey/src/common.rs:33:0-41:1)
- Change challenge-related types from byte vectors to strings
- Simplify challenge verification logic
- Replace `println!()` with `tracing::debug!()`

These changes reduce code complexity and improve type safety while maintaining the existing functionality of passkey authentication.