### PR TITLE
refactor: standardize public key storage as base64url strings

### DIFF
--- a/libpasskey/src/storage/passkey_store.rs
+++ b/libpasskey/src/storage/passkey_store.rs
@@ -99,7 +99,7 @@ async fn create_tables_sqlite(pool: &Pool<Sqlite>) -> Result<(), PasskeyError> {
         CREATE TABLE IF NOT EXISTS passkey_credentials (
             credential_id TEXT PRIMARY KEY NOT NULL,
             user_id TEXT NOT NULL REFERENCES users(id),
-            public_key BLOB NOT NULL,
+            public_key TEXT NOT NULL,
             counter INTEGER NOT NULL DEFAULT 0,
             user_handle TEXT NOT NULL,
             user_name TEXT NOT NULL,
@@ -268,7 +268,7 @@ async fn create_tables_postgres(pool: &Pool<Postgres>) -> Result<(), PasskeyErro
         CREATE TABLE IF NOT EXISTS passkey_credentials (
             credential_id TEXT PRIMARY KEY NOT NULL,
             user_id TEXT NOT NULL REFERENCES users(id),
-            public_key BYTEA NOT NULL,
+            public_key TEXT NOT NULL,
             counter INTEGER NOT NULL DEFAULT 0,
             user_handle TEXT NOT NULL,
             user_name TEXT NOT NULL,
@@ -442,7 +442,7 @@ impl<'r> FromRow<'r, SqliteRow> for StoredCredential {
     fn from_row(row: &'r SqliteRow) -> Result<Self, sqlx::Error> {
         let credential_id: String = row.try_get("credential_id")?;
         let user_id: String = row.try_get("user_id")?;
-        let public_key: Vec<u8> = row.try_get("public_key")?;
+        let public_key: String = row.try_get("public_key")?;
         let counter: i64 = row.try_get("counter")?;
         let user_handle: String = row.try_get("user_handle")?;
         let user_name: String = row.try_get("user_name")?;
@@ -471,7 +471,7 @@ impl<'r> FromRow<'r, PgRow> for StoredCredential {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
         let credential_id: String = row.try_get("credential_id")?;
         let user_id: String = row.try_get("user_id")?;
-        let public_key: Vec<u8> = row.try_get("public_key")?;
+        let public_key: String = row.try_get("public_key")?;
         let counter: i32 = row.try_get("counter")?;
         let user_handle: String = row.try_get("user_handle")?;
         let user_name: String = row.try_get("user_name")?;

--- a/libpasskey/src/types.rs
+++ b/libpasskey/src/types.rs
@@ -25,7 +25,7 @@ pub struct StoredCredential {
     /// User ID associated with this credential (database ID)
     pub user_id: String,
     /// Public key bytes for the credential
-    pub public_key: Vec<u8>,
+    pub public_key: String,
     /// Counter value for the credential (used to prevent replay attacks)
     pub counter: u32,
     /// User entity information


### PR DESCRIPTION
- Change public_key type from Vec<u8> to String in StoredCredential struct
- Update database schema to store public keys as TEXT instead of BLOB/BYTEA
- Modify registration flow to encode public keys as base64url strings
- Update authentication flow to decode public keys before verification
- Maintain binary format for cryptographic operations while using string format for storage

This change completes the standardization of binary data encoding throughout the backend codebase, using Base64 URL_SAFE_NO_PAD consistently for all credential IDs and public keys.