### PR TITLE
refactor: standardize cache data storage to use JSON strings

### DIFF
--- a/liboauth2/src/types.rs
+++ b/liboauth2/src/types.rs
@@ -132,7 +132,7 @@ pub(crate) struct OidcTokenResponse {
 impl From<StoredToken> for libstorage::CacheData {
     fn from(data: StoredToken) -> Self {
         Self {
-            value: serde_json::to_vec(&data).expect("Failed to serialize StoredToken"),
+            value: serde_json::to_string(&data).expect("Failed to serialize StoredToken"),
         }
     }
 }
@@ -141,7 +141,7 @@ impl TryFrom<libstorage::CacheData> for StoredToken {
     type Error = OAuth2Error;
 
     fn try_from(data: libstorage::CacheData) -> Result<Self, Self::Error> {
-        serde_json::from_slice(&data.value).map_err(|e| OAuth2Error::Storage(e.to_string()))
+        serde_json::from_str(&data.value).map_err(|e| OAuth2Error::Storage(e.to_string()))
     }
 }
 

--- a/libpasskey/src/common.rs
+++ b/libpasskey/src/common.rs
@@ -67,7 +67,7 @@ pub(crate) async fn name2cid_str_vec(
 impl From<SessionInfo> for libstorage::CacheData {
     fn from(data: SessionInfo) -> Self {
         Self {
-            value: serde_json::to_vec(&data).expect("Failed to serialize SessionInfo"),
+            value: serde_json::to_string(&data).expect("Failed to serialize SessionInfo"),
         }
     }
 }
@@ -76,14 +76,14 @@ impl TryFrom<libstorage::CacheData> for SessionInfo {
     type Error = PasskeyError;
 
     fn try_from(data: libstorage::CacheData) -> Result<Self, Self::Error> {
-        serde_json::from_slice(&data.value).map_err(|e| PasskeyError::Storage(e.to_string()))
+        serde_json::from_str(&data.value).map_err(|e| PasskeyError::Storage(e.to_string()))
     }
 }
 
 impl From<StoredOptions> for libstorage::CacheData {
     fn from(data: StoredOptions) -> Self {
         Self {
-            value: serde_json::to_vec(&data).expect("Failed to serialize StoredOptions"),
+            value: serde_json::to_string(&data).expect("Failed to serialize StoredOptions"),
         }
     }
 }
@@ -92,7 +92,7 @@ impl TryFrom<libstorage::CacheData> for StoredOptions {
     type Error = PasskeyError;
 
     fn try_from(data: libstorage::CacheData) -> Result<Self, Self::Error> {
-        serde_json::from_slice(&data.value).map_err(|e| PasskeyError::Storage(e.to_string()))
+        serde_json::from_str(&data.value).map_err(|e| PasskeyError::Storage(e.to_string()))
     }
 }
 

--- a/libsession/src/common.rs
+++ b/libsession/src/common.rs
@@ -35,7 +35,7 @@ pub(crate) fn header_set_cookie(
 impl From<StoredSession> for libstorage::CacheData {
     fn from(data: StoredSession) -> Self {
         Self {
-            value: serde_json::to_vec(&data).expect("Failed to serialize StoredSession"),
+            value: serde_json::to_string(&data).expect("Failed to serialize StoredSession"),
         }
     }
 }
@@ -44,6 +44,6 @@ impl TryFrom<libstorage::CacheData> for StoredSession {
     type Error = SessionError;
 
     fn try_from(data: libstorage::CacheData) -> Result<Self, Self::Error> {
-        serde_json::from_slice(&data.value).map_err(|e| SessionError::Storage(e.to_string()))
+        serde_json::from_str(&data.value).map_err(|e| SessionError::Storage(e.to_string()))
     }
 }

--- a/libstorage/src/types.rs
+++ b/libstorage/src/types.rs
@@ -3,5 +3,5 @@ use serde::{Deserialize, Serialize};
 /// Data stored in the cache
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheData {
-    pub value: Vec<u8>,
+    pub value: String,
 }


### PR DESCRIPTION
- Change CacheData.value from Vec<u8> to String
- Update all serialization/deserialization code to use to_string/from_str
- Improves consistency, readability, and debuggability of cached data