### PR TITLE
feat(storage): add configurable table names with environment variables

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,9 @@
 - Middleware based page protection i.e. create a likes of is_authorized middleware.
 - Consolidate liboauth2, libpasskey, libsession and libstorage into libauth.
 - We'll do this after the tests are implemented
-- Schema check when initializing database connection.
+- Schema check when initializing database connection. Make sure the schema the program is expecting is the same as the one in the database.
+- When using Delete User button, deletion of passkey credentials aren't notified to Passkey Authenticator.
+- Adjust visibility of functions, structs, enums, etc. What needs to be public?
 
 ## Half Done
 
@@ -18,7 +20,6 @@
 - Passkey sync between RP and Authenticator using signalAllAcceptedCredentials.
 - Enable modification of User.account and User.label for logged in user.
 - Enable deletion of logged in user then logout.
-
 - Enable deletion of Passkey credential for logged in user.
 - Enable unlinking of OAuth2 account for logged in user.
 - Examine if we should use OAuth2Coordinator and PasskeyCoordinator.
@@ -47,6 +48,7 @@
   - For Passkey credential addition:
     - Context token verification before initiating registration
     - Session verification during the registration process
+- Prefix of tables in database can be configured in .env file.
 
 ## Memo
 

--- a/clear_db_cache.sh
+++ b/clear_db_cache.sh
@@ -3,7 +3,7 @@
 #DB_STRING="psql postgres://passkey:passkey@localhost:5432/passkey"
 DB_STRING="sqlite3 /tmp/sqlite.db"
 
-echo "drop table users"| $DB_STRING
-echo "drop table passkey_credentials"| $DB_STRING
-echo "drop table oauth2_accounts"| $DB_STRING
+echo "drop table o2p_users"| $DB_STRING
+echo "drop table o2p_passkey_credentials"| $DB_STRING
+echo "drop table o2p_oauth2_accounts"| $DB_STRING
 redis-cli flushall

--- a/monitor_db.sh
+++ b/monitor_db.sh
@@ -9,9 +9,9 @@ SQLITE_HEADERS=".headers on"
 SQLITE_MODE=".mode column"
 
 # Define queries for each table
-QUERY_USERS="select id,account,label,created_at from users;"
-QUERY_PASSKEY_CREDENTIALS="select user_id,user_name,credential_id,public_key,created_at from passkey_credentials;"
-QUERY_OAUTH2_ACCOUNTS="select user_id,email,id,created_at from oauth2_accounts;"
+QUERY_USERS="select id,account,label,created_at from o2p_users;"
+QUERY_PASSKEY_CREDENTIALS="select user_id,user_name,credential_id,public_key,created_at from o2p_passkey_credentials;"
+QUERY_OAUTH2_ACCOUNTS="select user_id,email,id,created_at from o2p_oauth2_accounts;"
 
 #QUERY_PASSKEY_CREDENTIALS="select user_id,user_name,user_display_name,credential_id,public_key,created_at from passkey_credentials;"
 #QUERY_PASSKEY_CREDENTIALS="select user_id,hex(credential_id),user_handle,user_name,user_display_name,created_at from passkey_credentials;"

--- a/oauth2_passkey/src/storage/config.rs
+++ b/oauth2_passkey/src/storage/config.rs
@@ -1,0 +1,25 @@
+//! Database table configuration
+
+use std::env;
+use std::sync::LazyLock;
+
+/// Table prefix from environment variable
+pub static TABLE_PREFIX: LazyLock<String> =
+    LazyLock::new(|| env::var("DB_TABLE_PREFIX").unwrap_or_else(|_| "o2p_".to_string()));
+
+/// Users table name
+pub static DB_TABLE_USERS: LazyLock<String> = LazyLock::new(|| {
+    env::var("DB_TABLE_USERS").unwrap_or_else(|_| format!("{}{}", *TABLE_PREFIX, "users"))
+});
+
+/// Passkey credentials table name
+pub static DB_TABLE_PASSKEY_CREDENTIALS: LazyLock<String> = LazyLock::new(|| {
+    env::var("DB_TABLE_PASSKEY_CREDENTIALS")
+        .unwrap_or_else(|_| format!("{}{}", *TABLE_PREFIX, "passkey_credentials"))
+});
+
+/// OAuth2 accounts table name
+pub static DB_TABLE_OAUTH2_ACCOUNTS: LazyLock<String> = LazyLock::new(|| {
+    env::var("DB_TABLE_OAUTH2_ACCOUNTS")
+        .unwrap_or_else(|_| format!("{}{}", *TABLE_PREFIX, "oauth2_accounts"))
+});

--- a/oauth2_passkey/src/storage/mod.rs
+++ b/oauth2_passkey/src/storage/mod.rs
@@ -1,4 +1,5 @@
 mod cache;
+mod config;
 mod data;
 mod errors;
 mod types;
@@ -11,6 +12,7 @@ pub async fn init() -> Result<(), errors::StorageError> {
 }
 
 pub use cache::GENERIC_CACHE_STORE;
+pub use config::{DB_TABLE_OAUTH2_ACCOUNTS, DB_TABLE_PASSKEY_CREDENTIALS, DB_TABLE_USERS};
 pub use types::CacheData;
 
 pub use data::GENERIC_DATA_STORE;

--- a/oauth2_passkey/src/userdb/user/core.rs
+++ b/oauth2_passkey/src/userdb/user/core.rs
@@ -1,3 +1,4 @@
+use crate::storage::DB_TABLE_USERS;
 use crate::storage::GENERIC_DATA_STORE;
 use crate::userdb::{errors::UserError, types::User};
 use sqlx::{Pool, Postgres, Sqlite};
@@ -59,10 +60,12 @@ impl UserStore {
 
 // SQLite implementations
 async fn create_tables_sqlite(pool: &Pool<Sqlite>) -> Result<(), UserError> {
+    let table_name = DB_TABLE_USERS.as_str();
+
     // Create users table
-    sqlx::query(
+    sqlx::query(&format!(
         r#"
-        CREATE TABLE IF NOT EXISTS users (
+        CREATE TABLE IF NOT EXISTS {} (
             id TEXT PRIMARY KEY NOT NULL,
             account TEXT NOT NULL,
             label TEXT NOT NULL,
@@ -70,7 +73,8 @@ async fn create_tables_sqlite(pool: &Pool<Sqlite>) -> Result<(), UserError> {
             updated_at TIMESTAMP NOT NULL
         )
         "#,
-    )
+        table_name
+    ))
     .execute(pool)
     .await
     .map_err(|e| UserError::Storage(e.to_string()))?;
@@ -79,11 +83,14 @@ async fn create_tables_sqlite(pool: &Pool<Sqlite>) -> Result<(), UserError> {
 }
 
 async fn get_user_sqlite(pool: &Pool<Sqlite>, id: &str) -> Result<Option<User>, UserError> {
-    sqlx::query_as::<_, User>(
+    let table_name = DB_TABLE_USERS.as_str();
+
+    sqlx::query_as::<_, User>(&format!(
         r#"
-        SELECT * FROM users WHERE id = ?
+        SELECT * FROM {} WHERE id = ?
         "#,
-    )
+        table_name
+    ))
     .bind(id)
     .fetch_optional(pool)
     .await
@@ -91,10 +98,12 @@ async fn get_user_sqlite(pool: &Pool<Sqlite>, id: &str) -> Result<Option<User>, 
 }
 
 async fn upsert_user_sqlite(pool: &Pool<Sqlite>, user: User) -> Result<User, UserError> {
+    let table_name = DB_TABLE_USERS.as_str();
+
     // Upsert user with a single query
-    sqlx::query(
+    sqlx::query(&format!(
         r#"
-        INSERT INTO users (id, account, label, created_at, updated_at)
+        INSERT INTO {} (id, account, label, created_at, updated_at)
         VALUES (?, ?, ?, ?, ?)
         ON CONFLICT (id) DO UPDATE SET
             account = excluded.account,
@@ -102,7 +111,8 @@ async fn upsert_user_sqlite(pool: &Pool<Sqlite>, user: User) -> Result<User, Use
             created_at = excluded.created_at,
             updated_at = excluded.updated_at
         "#,
-    )
+        table_name
+    ))
     .bind(&user.id)
     .bind(&user.account)
     .bind(&user.label)
@@ -117,11 +127,14 @@ async fn upsert_user_sqlite(pool: &Pool<Sqlite>, user: User) -> Result<User, Use
 }
 
 async fn delete_user_sqlite(pool: &Pool<Sqlite>, id: &str) -> Result<(), UserError> {
-    sqlx::query(
+    let table_name = DB_TABLE_USERS.as_str();
+
+    sqlx::query(&format!(
         r#"
-        DELETE FROM users WHERE id = ?
+        DELETE FROM {} WHERE id = ?
         "#,
-    )
+        table_name
+    ))
     .bind(id)
     .execute(pool)
     .await
@@ -132,10 +145,12 @@ async fn delete_user_sqlite(pool: &Pool<Sqlite>, id: &str) -> Result<(), UserErr
 
 // PostgreSQL implementations
 async fn create_tables_postgres(pool: &Pool<Postgres>) -> Result<(), UserError> {
+    let table_name = DB_TABLE_USERS.as_str();
+
     // Create users table
-    sqlx::query(
+    sqlx::query(&format!(
         r#"
-        CREATE TABLE IF NOT EXISTS users (
+        CREATE TABLE IF NOT EXISTS {} (
             id TEXT PRIMARY KEY NOT NULL,
             account TEXT NOT NULL,
             label TEXT NOT NULL,
@@ -143,7 +158,8 @@ async fn create_tables_postgres(pool: &Pool<Postgres>) -> Result<(), UserError> 
             updated_at TIMESTAMPTZ NOT NULL
         )
         "#,
-    )
+        table_name
+    ))
     .execute(pool)
     .await
     .map_err(|e| UserError::Storage(e.to_string()))?;
@@ -152,11 +168,14 @@ async fn create_tables_postgres(pool: &Pool<Postgres>) -> Result<(), UserError> 
 }
 
 async fn get_user_postgres(pool: &Pool<Postgres>, id: &str) -> Result<Option<User>, UserError> {
-    sqlx::query_as::<_, User>(
+    let table_name = DB_TABLE_USERS.as_str();
+
+    sqlx::query_as::<_, User>(&format!(
         r#"
-        SELECT * FROM users WHERE id = $1
+        SELECT * FROM {} WHERE id = $1
         "#,
-    )
+        table_name
+    ))
     .bind(id)
     .fetch_optional(pool)
     .await
@@ -164,10 +183,12 @@ async fn get_user_postgres(pool: &Pool<Postgres>, id: &str) -> Result<Option<Use
 }
 
 async fn upsert_user_postgres(pool: &Pool<Postgres>, user: User) -> Result<User, UserError> {
+    let table_name = DB_TABLE_USERS.as_str();
+
     // Upsert user with a single query
-    sqlx::query(
+    sqlx::query(&format!(
         r#"
-        INSERT INTO users (id, account, label, created_at, updated_at)
+        INSERT INTO {} (id, account, label, created_at, updated_at)
         VALUES ($1, $2, $3, $4, $5)
         ON CONFLICT (id) DO UPDATE SET
             account = EXCLUDED.account,
@@ -176,7 +197,8 @@ async fn upsert_user_postgres(pool: &Pool<Postgres>, user: User) -> Result<User,
             updated_at = EXCLUDED.updated_at
         RETURNING *
         "#,
-    )
+        table_name
+    ))
     .bind(&user.id)
     .bind(&user.account)
     .bind(&user.label)
@@ -191,11 +213,14 @@ async fn upsert_user_postgres(pool: &Pool<Postgres>, user: User) -> Result<User,
 }
 
 async fn delete_user_postgres(pool: &Pool<Postgres>, id: &str) -> Result<(), UserError> {
-    sqlx::query(
+    let table_name = DB_TABLE_USERS.as_str();
+
+    sqlx::query(&format!(
         r#"
-        DELETE FROM users WHERE id = $1
+        DELETE FROM {} WHERE id = $1
         "#,
-    )
+        table_name
+    ))
     .bind(id)
     .execute(pool)
     .await


### PR DESCRIPTION
- Add LazyLock-based table name configuration in storage/config.rs
- Make table names configurable via environment variables:
  - DB_TABLE_PREFIX (default: "o2p_")
  - DB_TABLE_USERS
  - DB_TABLE_PASSKEY_CREDENTIALS
  - DB_TABLE_OAUTH2_ACCOUNTS
- Update all SQL queries to use configured table names
- Update helper scripts (clear_db_cache.sh, monitor_db.sh) to use new table names
- Add proper handling for table names with dots in index creation