### PR TITLE
refactor: reorganize authentication routes under a unified prefix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,8 +6,10 @@
 - We'll do this after the tests are implemented
 - Schema check when initializing database connection. Make sure the schema the program is expecting is the same as the one in the database.
 - When using Delete User button, deletion of passkey credentials aren't notified to Passkey Authenticator.
+- Decide on Public API
 - Adjust visibility of functions, structs, enums, etc. What needs to be public?
 - signalCurrentUserDetails seems not working on Android device.
+- Use tracing-error crate https://crates.io/crates/tracing-error
 
 ## Half Done
 
@@ -51,6 +53,12 @@
 - Prefix of tables in database can be configured in .env file.
 
 - Consolidate liboauth2, libpasskey, libsession and libstorage into libauth.
+
+- Want to change the directory structure of the endpoints for Passkey and OAuth2
+  - Currently Passkey endpoints should be mounted at OAUTH2_ROUTE_PREFIX(default: /passkey)
+  - OAuth2 endpoints should be mounted at OAUTH2_ROUTE_PREFIX(default: /oauth2)
+  - OAUTH2_ROUTE_PREFIX and PASSKEY_ROUTE_PREFIX are referenced by handlers and the endpoints are reflected in the templates and javascript files.
+  - I want to change it to O2P_ROUTE_PREFIX/passkey and O2P_ROUTE_PREFIX/oauth2 respectively. By doing so we only need to nest single tree in the application. The summary endpoint can be also nested in the same tree freeing from necessity of explicitly mounting it in the application.
 
 ## Memo
 

--- a/demo-integration/src/handlers.rs
+++ b/demo-integration/src/handlers.rs
@@ -3,7 +3,7 @@ use axum::{
     http::StatusCode,
     response::{Html, IntoResponse, Redirect, Response},
 };
-use oauth2_passkey::{OAUTH2_ROUTE_PREFIX, PASSKEY_ROUTE_PREFIX};
+use oauth2_passkey::{O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, SUMMARY_SUB_ROUTE};
 
 // use libsession::User;
 use libaxum::AuthUser as User;
@@ -36,11 +36,15 @@ pub(crate) async fn index(user: Option<User>) -> Result<Response, (StatusCode, S
     match user {
         Some(u) => {
             let message = format!("Hey {}!", u.account);
+            // Create the route strings first so they live long enough
+            let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
+            let passkey_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), PASSKEY_SUB_ROUTE);
+
             let template = IndexTemplateUser {
                 // user: u.clone(),
                 message: &message,
-                oauth_route_prefix: OAUTH2_ROUTE_PREFIX.as_str(),
-                passkey_route_prefix: PASSKEY_ROUTE_PREFIX.as_str(),
+                oauth_route_prefix: &oauth_route,
+                passkey_route_prefix: &passkey_route,
             };
             let _html = Html(
                 template
@@ -48,14 +52,18 @@ pub(crate) async fn index(user: Option<User>) -> Result<Response, (StatusCode, S
                     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
             );
             // Ok(html.into_response())
-            Ok(Redirect::to("/summary").into_response())
+            let summary_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), SUMMARY_SUB_ROUTE);
+            Ok(Redirect::to(&summary_route).into_response())
         }
         None => {
-            let message = "Click the Login button below.".to_string();
+            // Create the route strings first so they live long enough
+            let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
+            let passkey_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), PASSKEY_SUB_ROUTE);
+
             let template = IndexTemplateAnon {
-                message: &message,
-                oauth_route_prefix: OAUTH2_ROUTE_PREFIX.as_str(),
-                passkey_route_prefix: PASSKEY_ROUTE_PREFIX.as_str(),
+                message: "Welcome to the demo integration app!",
+                oauth_route_prefix: &oauth_route,
+                passkey_route_prefix: &passkey_route,
             };
             let html = Html(
                 template
@@ -68,9 +76,12 @@ pub(crate) async fn index(user: Option<User>) -> Result<Response, (StatusCode, S
 }
 
 pub(crate) async fn protected(user: User) -> Result<Html<String>, (StatusCode, String)> {
+    // Create the route string first so it lives long enough
+    let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
+
     let template = ProtectedTemplate {
         user,
-        oauth_route_prefix: OAUTH2_ROUTE_PREFIX.as_str(),
+        oauth_route_prefix: &oauth_route,
     };
     let html = Html(
         template

--- a/dot.env.example
+++ b/dot.env.example
@@ -9,16 +9,19 @@ OAUTH2_GOOGLE_CLIENT_SECRET='your-client-secret'
 
 ### Optional Environment Variables ###
 
+# Authentication Route Configuration
+# Main route prefix for all authentication endpoints (oauth2, passkey, summary)
+# Default: '/auth'
+O2P_ROUTE_PREFIX='/auth'
+
 # Token Store Configuration (optional, defaults to in-memory)
 #OAUTH2_TOKEN_STORE='redis'
 #OAUTH2_TOKEN_REDIS_URL='redis://localhost:6379'
 #OAUTH2_SESSION_STORE='redis'
 #OAUTH2_SESSION_REDIS_URL='redis://localhost:6379'
-#OAUTH2_ROUTE_PREFIX='/oauth2'  # Default value, can be customized
 
 ### Passkey Configuration (optional) ###
 
-# Route prefix for Passkey endpoints, defaults to '/passkey' PASSKEY_ROUTE_PREFIX
 # Storage type: memory (default), sqlite, postgres, or redis
 #PASSKEY_CHALLENGE_STORE='redis'
 #PASSKEY_CREDENTIAL_STORE='redis'

--- a/libaxum/src/lib.rs
+++ b/libaxum/src/lib.rs
@@ -1,6 +1,7 @@
 mod error;
 mod oauth2;
 mod passkey;
+mod router;
 mod session;
 mod summary;
 
@@ -8,5 +9,6 @@ pub use error::IntoResponseError;
 pub use oauth2::router as oauth2_router;
 pub use passkey::passkey_well_known_router;
 pub use passkey::router as passkey_router;
+pub use router::auth_router;
 pub use session::AuthUser;
 pub use summary::router as summary_router;

--- a/libaxum/src/oauth2.rs
+++ b/libaxum/src/oauth2.rs
@@ -11,9 +11,9 @@ use axum_extra::{TypedHeader, headers};
 use std::collections::HashMap;
 
 use oauth2_passkey::{
-    AuthResponse, OAUTH2_ROUTE_PREFIX, OAuth2Account, SessionUser, delete_oauth2_account_core,
-    get_authorized_core, list_accounts_core, post_authorized_core, prepare_logout_response,
-    prepare_oauth2_auth_request, verify_context_token_and_page,
+    AuthResponse, O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE, OAuth2Account, SessionUser,
+    delete_oauth2_account_core, get_authorized_core, list_accounts_core, post_authorized_core,
+    prepare_logout_response, prepare_oauth2_auth_request, verify_context_token_and_page,
 };
 
 use crate::AuthUser;
@@ -113,8 +113,9 @@ pub async fn get_authorized(
     Ok((
         headers,
         Redirect::to(&format!(
-            "{}/popup_close?message={}",
-            OAUTH2_ROUTE_PREFIX.as_str(),
+            "{}{}/popup_close?message={}",
+            O2P_ROUTE_PREFIX.as_str(),
+            OAUTH2_SUB_ROUTE,
             urlencoding::encode(&message)
         )),
     ))
@@ -140,8 +141,9 @@ pub async fn post_authorized(
     Ok((
         headers,
         Redirect::to(&format!(
-            "{}/popup_close?message={}",
-            OAUTH2_ROUTE_PREFIX.as_str(),
+            "{}{}/popup_close?message={}",
+            O2P_ROUTE_PREFIX.as_str(),
+            OAUTH2_SUB_ROUTE,
             urlencoding::encode(&message)
         )),
     ))

--- a/libaxum/src/passkey.rs
+++ b/libaxum/src/passkey.rs
@@ -7,11 +7,11 @@ use axum::{
 use serde_json::Value;
 
 use oauth2_passkey::{
-    AuthenticationOptions, AuthenticatorResponse, PASSKEY_ROUTE_PREFIX, PasskeyCredential,
-    RegisterCredential, RegistrationOptions, RegistrationStartRequest, SessionUser,
-    delete_passkey_credential_core, get_related_origin_json, handle_finish_authentication_core,
-    handle_finish_registration_core, handle_start_authentication_core,
-    handle_start_registration_core, list_credentials_core,
+    AuthenticationOptions, AuthenticatorResponse, O2P_ROUTE_PREFIX, PASSKEY_SUB_ROUTE,
+    PasskeyCredential, RegisterCredential, RegistrationOptions, RegistrationStartRequest,
+    SessionUser, delete_passkey_credential_core, get_related_origin_json,
+    handle_finish_authentication_core, handle_finish_registration_core,
+    handle_start_authentication_core, handle_start_registration_core, list_credentials_core,
 };
 
 use crate::IntoResponseError;
@@ -113,13 +113,13 @@ pub(crate) async fn serve_passkey_js() -> Response {
 
 #[derive(Template)]
 #[template(path = "conditional_ui.j2")]
-struct ConditionalUiTemplate {
-    passkey_route_prefix: &'static str,
+struct ConditionalUiTemplate<'a> {
+    passkey_route_prefix: &'a str,
 }
 
 pub(crate) async fn conditional_ui() -> impl IntoResponse {
     let template = ConditionalUiTemplate {
-        passkey_route_prefix: PASSKEY_ROUTE_PREFIX.as_str(),
+        passkey_route_prefix: &format!("{}{}", O2P_ROUTE_PREFIX.as_str(), PASSKEY_SUB_ROUTE),
     };
     (StatusCode::OK, Html(template.render().unwrap_or_default())).into_response()
 }

--- a/libaxum/src/router.rs
+++ b/libaxum/src/router.rs
@@ -1,0 +1,22 @@
+//! Combined router for all authentication endpoints
+
+use axum::Router;
+use oauth2_passkey::{OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, SUMMARY_SUB_ROUTE};
+
+use crate::{oauth2_router, passkey_router, summary_router};
+
+/// Create a combined router for all authentication endpoints
+///
+/// This router combines the OAuth2, Passkey, and Summary endpoints under a single mount point.
+/// The endpoints will be available at:
+/// - {O2P_ROUTE_PREFIX}/oauth2/...
+/// - {O2P_ROUTE_PREFIX}/passkey/...
+/// - {O2P_ROUTE_PREFIX}/summary/...
+///
+/// This simplifies integration by requiring only a single router to be mounted in the application.
+pub fn auth_router() -> Router {
+    Router::new()
+        .nest(OAUTH2_SUB_ROUTE, oauth2_router())
+        .nest(PASSKEY_SUB_ROUTE, passkey_router())
+        .nest(SUMMARY_SUB_ROUTE, summary_router())
+}

--- a/libaxum/src/summary/handlers.rs
+++ b/libaxum/src/summary/handlers.rs
@@ -9,7 +9,7 @@ use axum::{
 
 use oauth2_passkey::SessionUser;
 use oauth2_passkey::{
-    OAUTH2_ROUTE_PREFIX, PASSKEY_ROUTE_PREFIX, delete_user_account, list_accounts_core,
+    O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, delete_user_account, list_accounts_core,
     list_credentials_core, update_user_account,
 };
 
@@ -220,12 +220,17 @@ pub async fn user_summary(auth_user: AuthUser) -> Result<Html<String>, (StatusCo
         .collect();
 
     // Create template with all data
+    // Create the route strings first
+    let oauth_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), OAUTH2_SUB_ROUTE);
+    let passkey_route = format!("{}{}", O2P_ROUTE_PREFIX.as_str(), PASSKEY_SUB_ROUTE);
+
     let template = UserSummaryTemplate::new(
         auth_user,
         passkey_credentials,
         oauth2_accounts,
-        OAUTH2_ROUTE_PREFIX.as_str(),
-        PASSKEY_ROUTE_PREFIX.as_str(),
+        // Pass owned String values to the template
+        oauth_route,
+        passkey_route,
     );
 
     // Render the template

--- a/libaxum/src/summary/templates.rs
+++ b/libaxum/src/summary/templates.rs
@@ -36,8 +36,8 @@ pub struct UserSummaryTemplate {
     pub user: AuthUser,
     pub passkey_credentials: Vec<TemplateCredential>,
     pub oauth2_accounts: Vec<TemplateAccount>,
-    pub oauth_route_prefix: &'static str,
-    pub passkey_route_prefix: &'static str,
+    pub oauth_route_prefix: String,
+    pub passkey_route_prefix: String,
     pub obfuscated_user_id: String,
 }
 
@@ -46,8 +46,8 @@ impl UserSummaryTemplate {
         user: AuthUser,
         passkey_credentials: Vec<TemplateCredential>,
         oauth2_accounts: Vec<TemplateAccount>,
-        oauth_route_prefix: &'static str,
-        passkey_route_prefix: &'static str,
+        oauth_route_prefix: String,
+        passkey_route_prefix: String,
     ) -> Self {
         let obfuscated_user_id = obfuscate_user_id(&user.id);
 

--- a/oauth2_passkey/src/config.rs
+++ b/oauth2_passkey/src/config.rs
@@ -1,0 +1,28 @@
+//! Central configuration for the oauth2_passkey crate
+
+use std::sync::LazyLock;
+
+/// Route prefix for all oauth2_passkey endpoints
+///
+/// This is the main prefix under which all authentication endpoints will be mounted.
+/// Default: "/o2p"
+pub static O2P_ROUTE_PREFIX: LazyLock<String> =
+    LazyLock::new(|| std::env::var("O2P_ROUTE_PREFIX").unwrap_or_else(|_| "/o2p".to_string()));
+
+/// Sub-route for OAuth2 endpoints
+///
+/// This will be mounted under O2P_ROUTE_PREFIX
+/// Full path: {O2P_ROUTE_PREFIX}/oauth2
+pub const OAUTH2_SUB_ROUTE: &str = "/oauth2";
+
+/// Sub-route for Passkey endpoints
+///
+/// This will be mounted under O2P_ROUTE_PREFIX
+/// Full path: {O2P_ROUTE_PREFIX}/passkey
+pub const PASSKEY_SUB_ROUTE: &str = "/passkey";
+
+/// Sub-route for Summary endpoints
+///
+/// This will be mounted under O2P_ROUTE_PREFIX
+/// Full path: {O2P_ROUTE_PREFIX}/summary
+pub const SUMMARY_SUB_ROUTE: &str = "/summary";

--- a/oauth2_passkey/src/coordination/oauth2.rs
+++ b/oauth2_passkey/src/coordination/oauth2.rs
@@ -206,7 +206,7 @@ pub async fn delete_oauth2_account_core(
     provider_user_id: &str,
 ) -> Result<(), CoordinationError> {
     // Ensure user is authenticated
-    let user = user.ok_or(CoordinationError::Unauthorized.log())?;
+    let user = user.ok_or_else(|| CoordinationError::Unauthorized.log())?;
 
     // Get the OAuth2 account to verify it belongs to the user
     let accounts = OAuth2Store::get_oauth2_accounts_by(AccountSearchField::ProviderUserId(
@@ -258,7 +258,8 @@ pub async fn list_accounts_core(
     user: Option<&SessionUser>,
 ) -> Result<Vec<OAuth2Account>, CoordinationError> {
     // Ensure user is authenticated
-    let user = user.ok_or(CoordinationError::Unauthorized.log())?;
+    let user = user.ok_or_else(|| CoordinationError::Unauthorized.log())?;
+    tracing::trace!("list_accounts_core: User: {:#?}", user);
 
     get_oauth2_accounts(&user.id).await
 }

--- a/oauth2_passkey/src/coordination/passkey.rs
+++ b/oauth2_passkey/src/coordination/passkey.rs
@@ -211,9 +211,9 @@ pub async fn list_credentials_core(
     user: Option<&SessionUser>,
 ) -> Result<Vec<PasskeyCredential>, CoordinationError> {
     // Ensure user is authenticated
-    let user = user.ok_or(CoordinationError::Unauthorized.log())?;
+    let user = user.ok_or_else(|| CoordinationError::Unauthorized.log())?;
 
-    tracing::debug!("list_credentials_core: User: {:#?}", user);
+    tracing::trace!("list_credentials_core: User: {:#?}", user);
     let credentials =
         PasskeyStore::get_credentials_by(CredentialSearchField::UserId(user.id.to_owned())).await?;
     Ok(credentials)
@@ -228,7 +228,7 @@ pub async fn delete_passkey_credential_core(
     credential_id: &str,
 ) -> Result<(), CoordinationError> {
     // Ensure user is authenticated
-    let user = user.ok_or(CoordinationError::Unauthorized.log())?;
+    let user = user.ok_or_else(|| CoordinationError::Unauthorized.log())?;
 
     tracing::debug!("delete_passkey_credential_core: User: {:#?}", user);
     tracing::debug!("Attempting to delete credential with ID: {}", credential_id);

--- a/oauth2_passkey/src/lib.rs
+++ b/oauth2_passkey/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate provides coordination between different authentication mechanisms
 //! including OAuth2, Passkey, and user database operations.
 
+mod config;
 mod coordination;
 mod oauth2;
 mod passkey;
@@ -28,20 +29,22 @@ pub use coordination::{
     post_authorized_core, update_user_account,
 };
 
-pub use oauth2::{
-    AuthResponse, OAUTH2_ROUTE_PREFIX, OAuth2Account, OAuth2Error, prepare_oauth2_auth_request,
-};
+// Re-export the route prefixes
+pub use config::{O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE, PASSKEY_SUB_ROUTE, SUMMARY_SUB_ROUTE};
+
+pub use oauth2::{AuthResponse, OAuth2Account, OAuth2Error, prepare_oauth2_auth_request};
 
 pub use passkey::{
-    AuthenticationOptions, AuthenticatorResponse, PASSKEY_ROUTE_PREFIX, PasskeyCredential,
-    RegisterCredential, RegistrationOptions, get_related_origin_json,
+    AuthenticationOptions, AuthenticatorResponse, PasskeyCredential, RegisterCredential,
+    RegistrationOptions, get_related_origin_json,
 };
 
 pub use session::{
     SESSION_COOKIE_NAME, SessionError, User as SessionUser, get_user_from_session,
-    prepare_logout_response,
+    // is_authenticated_basic, is_authenticated_strict,
+    obfuscate_user_id, prepare_logout_response,
+    verify_context_token_and_page,
 };
-pub use session::{obfuscate_user_id, verify_context_token_and_page};
 
 /// Initialize the authentication coordination layer
 pub async fn init() -> Result<(), Box<dyn std::error::Error>> {

--- a/oauth2_passkey/src/oauth2/config.rs
+++ b/oauth2_passkey/src/oauth2/config.rs
@@ -1,3 +1,4 @@
+use crate::config::{O2P_ROUTE_PREFIX, OAUTH2_SUB_ROUTE};
 use std::{env, sync::LazyLock};
 
 pub(crate) static OAUTH2_USERINFO_URL: &str = "https://www.googleapis.com/userinfo/v2/me";
@@ -54,17 +55,12 @@ pub(crate) static OAUTH2_CSRF_COOKIE_MAX_AGE: LazyLock<u64> = LazyLock::new(|| {
         .unwrap_or(60) // Default to 60 seconds if not set or invalid
 });
 
-pub static OAUTH2_ROUTE_PREFIX: LazyLock<String> = LazyLock::new(|| {
-    std::env::var("OAUTH2_ROUTE_PREFIX")
-        .ok()
-        .unwrap_or("/oauth2".to_string())
-});
-
 pub(crate) static OAUTH2_REDIRECT_URI: LazyLock<String> = LazyLock::new(|| {
     format!(
-        "{}{}/authorized",
+        "{}{}{}/authorized",
         env::var("ORIGIN").expect("Missing ORIGIN!"),
-        OAUTH2_ROUTE_PREFIX.as_str()
+        O2P_ROUTE_PREFIX.as_str(),
+        OAUTH2_SUB_ROUTE
     )
 });
 

--- a/oauth2_passkey/src/oauth2/mod.rs
+++ b/oauth2_passkey/src/oauth2/mod.rs
@@ -6,7 +6,7 @@ mod types;
 
 pub(super) use types::{StateParams, StoredToken};
 
-pub use config::{OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME, OAUTH2_ROUTE_PREFIX};
+pub use config::{OAUTH2_AUTH_URL, OAUTH2_CSRF_COOKIE_NAME};
 
 pub use errors::OAuth2Error;
 pub use main::{

--- a/oauth2_passkey/src/passkey/config.rs
+++ b/oauth2_passkey/src/passkey/config.rs
@@ -1,11 +1,5 @@
 use std::{env, sync::LazyLock};
 
-pub static PASSKEY_ROUTE_PREFIX: LazyLock<String> = LazyLock::new(|| {
-    std::env::var("PASSKEY_ROUTE_PREFIX")
-        .ok()
-        .unwrap_or("/passkey".to_string())
-});
-
 pub(crate) static ORIGIN: LazyLock<String> =
     LazyLock::new(|| std::env::var("ORIGIN").expect("ORIGIN must be set"));
 

--- a/oauth2_passkey/src/passkey/mod.rs
+++ b/oauth2_passkey/src/passkey/mod.rs
@@ -4,7 +4,6 @@ mod main;
 mod storage;
 mod types;
 
-pub use config::PASSKEY_ROUTE_PREFIX; // Required for route configuration
 pub use errors::PasskeyError;
 
 pub use main::{

--- a/oauth2_passkey/src/userdb/errors.rs
+++ b/oauth2_passkey/src/userdb/errors.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug)]
 pub enum UserError {
     #[error("User not found")]
     NotFound,


### PR DESCRIPTION
Implement a more maintainable route structure by:
- Creating a unified mount point (O2P_ROUTE_PREFIX) for all auth endpoints
- Organizing OAuth2, Passkey and Summary endpoints as sub-routes
- Adding a combined auth_router() to simplify integration
- Improving error handling with ok_or_else() for better diagnostics
- Adjusting log levels for better performance (debug → trace)
- Making UserError cloneable to support proper error propagation

This change simplifies application integration by requiring only a single router to be mounted while maintaining the same functionality.